### PR TITLE
Affine sigmoid bijector and mixtures of affine sigmoid

### DIFF
--- a/notebooks/score_matching/NF_mixture_sigmoid.ipynb
+++ b/notebooks/score_matching/NF_mixture_sigmoid.ipynb
@@ -1,0 +1,585 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view-in-github",
+        "colab_type": "text"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/astrodeepnet/sbi_experiments/blob/affine_sigmoid_bijecctor/notebooks/score_matching/NF_mixture_sigmoid.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "-ksfVXYDmE17",
+      "metadata": {
+        "id": "-ksfVXYDmE17"
+      },
+      "source": [
+        "# Nomalizing Flow with implicit coupling layers\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "id": "3830d842",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "3830d842",
+        "outputId": "b839a062-ae62-4c52-e9b7-6cb96714b648"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "\u001b[K     |████████████████████████████████| 1.7 MB 5.2 MB/s \n",
+            "     |████████████████████████████████| 850 kB 5.6 MB/s            \n",
+            "\u001b[?25h  Preparing metadata (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
+            "     |████████████████████████████████| 149.4 MB 16 kB/s             \n",
+            "\u001b[?25h  Building wheel for jax (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
+            "\u001b[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv\u001b[0m\n",
+            "     |████████████████████████████████| 287 kB 5.4 MB/s            \n",
+            "     |████████████████████████████████| 126 kB 69.4 MB/s            \n",
+            "     |████████████████████████████████| 98 kB 9.7 MB/s             \n",
+            "     |████████████████████████████████| 65 kB 3.7 MB/s             \n",
+            "\u001b[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv\u001b[0m\n",
+            "\u001b[?25h  Preparing metadata (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
+            "  Building wheel for SBIExperiments (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
+            "\u001b[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv\u001b[0m\n"
+          ]
+        }
+      ],
+      "source": [
+        "!pip install --quiet --upgrade pip\n",
+        "# Installs the wheel compatible with CUDA 11 and cuDNN 8.2 or newer.\n",
+        "!pip install --quiet --upgrade \"jax[cuda]\" -f https://storage.googleapis.com/jax-releases/jax_releases.html  # Note: wheels only available on linux.\n",
+        "!pip install --quiet --upgrade dm-haiku optax tensorflow-probability jaxopt\n",
+        "!pip install --quiet git+https://github.com/astrodeepnet/sbi_experiments.git@affine_sigmoid_bijecctor"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "id": "Hc32pZP7mvkJ",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "Hc32pZP7mvkJ",
+        "outputId": "54786a88-84a0-4a8d-a5f4-ed83b446d6f9"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Populating the interactive namespace from numpy and matplotlib\n"
+          ]
+        }
+      ],
+      "source": [
+        "%pylab inline\n",
+        "%load_ext autoreload\n",
+        "%autoreload 2\n",
+        "import jax\n",
+        "import jax.numpy as jnp\n",
+        "import numpy as onp\n",
+        "import haiku as hk\n",
+        "import optax\n",
+        "from functools import partial\n",
+        "from tqdm import tqdm\n",
+        "from tensorflow_probability.substrates import jax as tfp\n",
+        "tfd = tfp.distributions\n",
+        "tfb = tfp.bijectors\n",
+        "tfpk = tfp.math.psd_kernels"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "id": "Vjg7DR8Mm3ma",
+      "metadata": {
+        "id": "Vjg7DR8Mm3ma"
+      },
+      "outputs": [],
+      "source": [
+        "d=2\n",
+        "batch_size = 1024"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "id": "SCV_fApFm5B6",
+      "metadata": {
+        "id": "SCV_fApFm5B6"
+      },
+      "outputs": [],
+      "source": [
+        "from sbiexpt.distributions import get_two_moons\n",
+        "from sbiexpt.bijectors import MixtureAffineSigmoidBijector "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 7,
+      "id": "QlkFc_kMFwdp",
+      "metadata": {
+        "id": "QlkFc_kMFwdp"
+      },
+      "outputs": [],
+      "source": [
+        "@jax.jit\n",
+        "def get_batch(seed):\n",
+        "  two_moons = get_two_moons(sigma = 0.01, normalized=True)\n",
+        "  #seed = jax.random.PRNGKey(0)  # Uncomment to fix the samples\n",
+        "  batch = two_moons.sample(batch_size, seed=seed)\n",
+        "  score = jax.vmap(jax.grad(two_moons.log_prob))(batch)\n",
+        "  return batch, score"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 8,
+      "id": "chc6hgEwxoJO",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 269
+        },
+        "id": "chc6hgEwxoJO",
+        "outputId": "e507dfbf-b204-4ac7-f503-3f94d188cdde"
+      },
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAQYAAAD8CAYAAACVSwr3AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAATd0lEQVR4nO3db4wdV3nH8e8PO04wtUPskAC24zjCQbhQidQ4BKQSlFA5RrJf0CAboTati4ESqEJFlYqKP+EVVAUJyS2xSvgnQXDyol0Jg6vQWJEoxjYKBOzIsNgk2fAn4IQoikNsq09fzJzd2Tm7e2ftuXPvNb+PZO2duefe++z16jnPnDlzRhGBmVnVCwYdgJkNHycGM8s4MZhZxonBzDJODGaWcWIws0zPxCDpLklPSPrxLM9L0mcljUt6SNI17YdpZl1qUjF8Edg4x/M3AWvLfzuAfz/3sMxskHomhoh4AHhyjiZbgC9HYT/wYkkvaytAM+vewhbeYwXwWGV7otz3y3pDSTsoqgoWsOBPF7O0hY83s9k8w1O/jYiXzPd1bSSGxiJiF7ALYKmWxbW6ocuPN/uDc1/c+8jZvK6NsxKPA6sq2yvLfWY2otpIDGPAX5ZnJ14PPB0R2WGEmY2OnocSkr4GXA9cKmkC+ChwAUBEfA7YA2wCxoGTwF/3K1gz60bPxBAR23o8H8D7WovIzAbOMx/NLOPEYGYZJwYzyzgxmFnGicHMMk4MZpZxYjCzjBODmWWcGMws48RgZhknBjPLODGYWcaJwcwyTgxmlnFiMLOME4OZZZwYzCzjxGBmGScGM8s4MZhZxonBzDJODGaWcWIws4wTg5llnBjMLOPEYGYZJwYzyzgxmFnGicHMMk4MZpZxYjCzjBODmWWcGMws48RgZhknBjPLNEoMkjZKOippXNLtMzx/haT7JT0o6SFJm9oP1cy60jMxSFoA7ARuAtYB2yStqzX7Z2B3RLwW2Ar8W9uBmll3mlQMG4DxiDgWEaeAu4EttTYBLC0fXwz8or0QzaxrCxu0WQE8VtmeAK6ttfkY8N+S3g+8CLhxpjeStAPYAXARi+cbq5l1pK3Bx23AFyNiJbAJ+Iqk7L0jYldErI+I9RdwYUsfbWZta5IYHgdWVbZXlvuqtgO7ASLiu8BFwKVtBGhm3WuSGA4CayWtkbSIYnBxrNbmUeAGAEmvokgMv2kzUDPrTs/EEBFngFuBvcDDFGcfDku6Q9Lmstk/AO+S9EPga8AtERH9CtrM+qvJ4CMRsQfYU9v3kcrjI8Ab2w3NzAbFMx/NLOPEYGYZJwYzyzgxmFnGicHMMk4MZpZxYjCzjBODmWWcGMws48RgZhknBjPLODGYWcaJwcwyTgxmlnFiMLOME4OZZZwYzCzjxGBmGScGM8s4MZhZxonB5rTwla9g4StfMegwrGNODGaWcWIws0yj+0rY8Enl/Zmj47M+l6Q2pza+DoDFx5+a9X1PrrkEgEXfOthKnDaaXDGYWcYVw4iZrVJI1QDAidUXAPDkhtMALDvwhtq7FFXBM2U7gGdfXvy84qP/W7zHu4vXLHmkeI9FR6d/ftVssbjqGF2uGMws44phxKQxgGeuL3r05XcWPfwjN0+1WXag+PmqTxVjCSc+IwBe+NkXT2u7+p7Tk6+5fF/R9tdlpZAqiGdfXlYV1xX7r/rqE1ksWTXhSmHkuWIws4wGdbf6pVoW1+qGgXz2sKmPGzz68akxgZd+tzzGL3vh+rH/r64revRqT/7r6y8D4PJ9U/uq7z9XDL08/I+XTD5eduCCabHMJZ0JmSsGa999ce/3I2L9fF/nisHMMh5jGCKp105VAkz1tCfLkf5UBaSqIJ1FOFk5K5HazKd3nq1tiimNJ6Qqofo56bnnPvA7YGosI1UzAFcdbxyKDQFXDGaW8RjDANSP51Pvn84EXPy630w+d+a/XjKtbX3coOuZivO5oCrFBvlsS481dKOvYwySNko6Kmlc0u2ztHm7pCOSDkv66nwDMbPh0XOMQdICYCfwFmACOChpLCKOVNqsBf4JeGNEPCXpsn4FbGb912TwcQMwHhHHACTdDWwBjlTavAvYGRFPAUTEE9m7WGaynC4PJZ5fWQw6psE7gMXHawOJtVObaXJRV5ocAqTTrdVB1HS4lFw+j/ez7jU5lFgBPFbZnij3VV0NXC3pO5L2S9o40xtJ2iHpkKRDp3n+7CI2s75r63TlQmAtcD2wEnhA0msi4nfVRhGxC9gFxeBjS589clIvmSYrTQ0oFr1qqhKqbUdJOoVavbArqZ/iXMzsl4/b4DSpGB4HVlW2V5b7qiaAsYg4HRHHgZ9QJAozG0FNKoaDwFpJaygSwlbgHbU2/wlsA74g6VKKQ4tjbQY6quY6vbdwS3lacl/xo8nEpFHqWaunKBd9a/oYSd1cC89Y93pWDBFxBrgV2As8DOyOiMOS7pC0uWy2Fzgh6QhwP/ChiDjRr6DNrL88wanPZlpOrTrxp/rcH0JvWR93SNOok4s3/bTLcM57vojKzFrji6j6JB0znyq3j71j6jz+i34xve3i2gVG1XGJNquI+nF8vz5nLvWp2899oBijTlO/H/341BTw9D2lxWhGwfmyrJ0rBjPLODGYWcaHEn0yWZqvKUrL6vTgepl5ZrbX9snkAOAAy910GLP8tmLw++Sa4vuZXGOS0TqESNL/7SAO09rkisHMMq4YWlaf0LT3rv8A4M1/87eDCGea1HOlacjVVZ+6HizLetGysqquXVm/YGyY1dfiXDjH3b5GgSsGM8u4YmhJqhTqKzQPQ6VQl1Z6TvedgKnqoeuVoFI1MHVXrEvyxmuG/xRgfS3OZ1ZPnZ5ePgIVT50rBjPLuGJoWf2y4tQTDsMIe+qlU6VQPXafvLNVR7HUxw3qa1nC1KSwdBn3MMou/iorhur/9yheIOaKwcwyrhhaVh9jmLzceIikMYZjN/1wct9b31z2agOJaEq1V73io8Xjp/cU06bTnIeZ2g6LyUvp75zaN4xx9uKKwcwyrhhaksYU0r0h6neCHibpblLrD7x3ct+ScubhoJZam+nz0rH51OK4wzc3oL5M37PliZMz7566GGwYxpfmyxWDmWWcGMws40OJlk2b0svgB/OqUtmb7ulQvddDugHti8qJOcN034dHbi5+LjtQxJamHQ/TYVqK6fJ9+eHOMP0NNOWKwcwyrhjOURogO1FOZEpTYYd5wCkNjKZerng8vc0wVArJ6nuKn7+6rviZeuVh6InT///T5dqVi2+bvc0wfae9uGIws4wrhpak3ndyNegh7iXqt6SHyp2hjg9Pb1y/TPylM11gNSCpCpictr2pqBC7vhitX1wxmFnGFcM5ql8s9cjNxfba7cPfY1TPSqSpvM8hAJbfNjwVT+qVp1bXHr7JY/X7hwxDxXUuXDGYWcYVwzlKx5JLyh5j+Z3TFwMdhh53NtWzEs+U93V4ckOxb3k5/bh+R+4uf5/0HaaFdIfhjl31JdySVDEO40VzZ8MVg5llXDG0JFUOw7A0e1PVkfOpBVqKHvHEZ4qxhmcH+GvUx2+GoTeuL+E2infLasIVg5llnBjMLONDiZZM3k9iBA4hZrqpbd3TB4vByDTwl0rnLlc8Toc66TCnPqDb1Q1kT1Xuv/HT8oKuCyeKn/UbFJ8vXDGYWcYVQ0uG+bTkbGaKuX5J9nPlxUFLJldRmtL1Kdn65wxiMlG6oOuZ1cXPydO4HcbQBVcMZpZxxWDTpF55STpVWE58euTmYqzhwuveMNl20Pd76HelkiqiNK4AU/fk+NV1l3USw6A0qhgkbZR0VNK4pNvnaPc2SSFpfXshmlnXelYMkhYAO4G3ABPAQUljEXGk1m4J8PfA9/oRqHUrHb9PTSrKpwKnHnVyRexvjc508Kr62Zn0+zxaLneXzkDA1O+U7nlxvmpSMWwAxiPiWEScAu4GtszQ7hPAJ4HftxifmQ1AkzGGFcBjle0J4NpqA0nXAKsi4huSPjTbG0naAewAuIjF84/WOpd60zTlN11EBLD4ePEzLSR71fHRqRSqVUKqEJJULV11fObnq68fhd/1bJzz4KOkFwCfBm7p1TYidgG7AJZqWfRobmYD0iQxPA6sqmyvLPclS4BXA/skAbwUGJO0OSIOtRWodaveE6bZf9W7UtcvJJpaUGVwC+LWe/LZLhuvVgHpIq3UJt3bMy22M9OCMOdrpZA0GWM4CKyVtEbSImArMJaejIinI+LSiLgyIq4E9gNOCmYjrGdiiIgzwK3AXuBhYHdEHJZ0h6TN/Q7QzLqniMEc6i/VsrhWNwzks+3szXThVTqEqN+FK+2HfBWm+inOc40hyVa7Lkv+n36+OBSaukfFBZOvSYdC1cOk6mtH2X1x7/cjYt7zijwl2swynhJt81LtRVPPnSqFem9dvSQ5VQaTFxutKXrw+urKc6lXJvXLryFfrXv1PcVzyw4U+9PdrOa6XPp8qBTOlSsGM8u4YrCzVu9ZJ0/rzTEGkE4fPvvy6fsv/kCxxuQLK5d3pyqiflo0badLxNN9Q6vvmyqE+uXRSfV0ZVbNmCsGM8u5YrDWpUpirmXg0lmKNCaw/LZ0dmxqrGGyIikrhHQBV/WMAkyvBtI4RNqXKoP6+Meo31uy31wxmFnGFYN1Kk2TTmc00mXd6fh+pjkK9enM6WKtybGGSsWQFo9J71efzuxxhGZcMZhZxonBzDI+lLChMtPkovq+tH35LM/buXPFYGYZVww2EG308q4U+scVg5llnBjMLOPEYGYZJwYzyzgxmFnGicHMMk4MZpZxYjCzjBODmWWcGMws48RgZhknBjPLODGYWcaJwcwyTgxmlnFiMLOME4OZZZwYzCzjxGBmGScGM8s4MZhZplFikLRR0lFJ45Jun+H5D0o6IukhSd+WtLr9UM2sKz0Tg6QFwE7gJmAdsE3SulqzB4H1EfEnwL3Ap9oO1My606Ri2ACMR8SxiDgF3A1sqTaIiPsj4mS5uR9Y2W6YZtalJolhBfBYZXui3Deb7cA3Z3pC0g5JhyQdOs3zzaM0s061eicqSe8E1gNvmun5iNgF7AJYqmXR5mebWXuaJIbHgVWV7ZXlvmkk3Qh8GHhTRLgcMBthTQ4lDgJrJa2RtAjYCoxVG0h6LXAnsDkinmg/TDPrUs/EEBFngFuBvcDDwO6IOCzpDkmby2b/AvwRcI+kH0gam+XtzGwENBpjiIg9wJ7avo9UHt/YclxmNkCe+WhmGScGM8s4MZhZxonBzDJODGaWcWIws4wTg5llnBjMLOPEYGYZJwYzyzgxmFnGicHMMk4MZpZxYjCzjBODmWWcGMws48RgZhknBjPLODGYWcaJwcwyTgxmlnFiMLOME4OZZZwYzCzjxGBmGScGM8s4MZhZxonBzDJODGaWcWIws4wTg5llnBjMLOPEYGYZJwYzyzgxmFmmUWKQtFHSUUnjkm6f4fkLJX29fP57kq5sO1Az607PxCBpAbATuAlYB2yTtK7WbDvwVES8AvgM8Mm2AzWz7jSpGDYA4xFxLCJOAXcDW2pttgBfKh/fC9wgSe2FaWZdWtigzQrgscr2BHDtbG0i4oykp4HlwG+rjSTtAHaUm8/fF/f++GyCHpBLqf0+Q2yUYoXRineUYgV45dm8qEliaE1E7AJ2AUg6FBHru/z8czFK8Y5SrDBa8Y5SrFDEezava3Io8TiwqrK9stw3YxtJC4GLgRNnE5CZDV6TxHAQWCtpjaRFwFZgrNZmDPir8vFfAP8TEdFemGbWpZ6HEuWYwa3AXmABcFdEHJZ0B3AoIsaAzwNfkTQOPEmRPHrZdQ5xD8IoxTtKscJoxTtKscJZxit37GZW55mPZpZxYjCzTN8TwyhNp24Q6wclHZH0kKRvS1o9iDgr8cwZb6Xd2ySFpIGdZmsSq6S3l9/vYUlf7TrGWiy9/haukHS/pAfLv4dNg4izjOUuSU9ImnFekAqfLX+XhyRd0/NNI6Jv/ygGK38GXAUsAn4IrKu1+Tvgc+XjrcDX+xnTOcb6ZmBx+fi9g4q1abxluyXAA8B+YP2wxgqsBR4ELim3Lxvm75ZiUO+95eN1wM8HGO+fAdcAP57l+U3ANwEBrwe+1+s9+10xjNJ06p6xRsT9EXGy3NxPMadjUJp8twCfoLh25fddBlfTJNZ3ATsj4imAiHii4xirmsQbwNLy8cXALzqMb3ogEQ9QnA2czRbgy1HYD7xY0svmes9+J4aZplOvmK1NRJwB0nTqrjWJtWo7RRYelJ7xliXjqoj4RpeBzaDJd3s1cLWk70jaL2ljZ9HlmsT7MeCdkiaAPcD7uwntrMz3b7vbKdHnC0nvBNYDbxp0LLOR9ALg08AtAw6lqYUUhxPXU1RiD0h6TUT8bqBRzW4b8MWI+FdJ11HM43l1RPzfoANrQ78rhlGaTt0kViTdCHwY2BwRz3cU20x6xbsEeDWwT9LPKY4txwY0ANnku50AxiLidEQcB35CkSgGoUm824HdABHxXeAiigushlGjv+1p+jwoshA4BqxhahDnj2tt3sf0wcfdAxrAaRLraykGpdYOIsb5xltrv4/BDT42+W43Al8qH19KUfouH+J4vwncUj5+FcUYgwb493Alsw8+vpXpg48Her5fBwFvosj+PwM+XO67g6LHhSLT3gOMAweAqwb45faK9T7g18APyn9jg4q1Sby1tgNLDA2/W1Ec+hwBfgRsHebvluJMxHfKpPED4M8HGOvXgF8Cpykqr+3Ae4D3VL7bneXv8qMmfweeEm1mGc98NLOME4OZZZwYzCzjxGBmGScGM8s4MZhZxonBzDL/DwOBaKCRADquAAAAAElFTkSuQmCC\n",
+            "text/plain": [
+              "<Figure size 432x288 with 1 Axes>"
+            ]
+          },
+          "metadata": {
+            "needs_background": "light"
+          }
+        }
+      ],
+      "source": [
+        "batch, score = get_batch(jax.random.PRNGKey(0))\n",
+        "hist2d(batch[:,0], batch[:,1],100, range=[[0,1],[0,1]]); gca().set_aspect('equal');"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 26,
+      "id": "VJDFS8Gd7zTQ",
+      "metadata": {
+        "id": "VJDFS8Gd7zTQ"
+      },
+      "outputs": [],
+      "source": [
+        "class CustomCoupling(hk.Module):\n",
+        "  \"\"\"This is the coupling layer used in the Flow.\"\"\"\n",
+        "  def __call__(self, x, output_units, **condition_kwargs):\n",
+        "\n",
+        "    # NN to get a b and c\n",
+        "    net = hk.Linear(256, name='l1')(x)\n",
+        "    net = jax.nn.silu(net)\n",
+        "    net = hk.Linear(256, name='l2')(net)\n",
+        "    net = jax.nn.silu(net)\n",
+        "    \n",
+        "    log_a_bound=4\n",
+        "    min_density_lower_bound=1e-4\n",
+        "    n_components = 16\n",
+        "    \n",
+        "    log_a = jax.nn.tanh(hk.Linear(output_units*n_components, name='l3')(net)) * log_a_bound\n",
+        "    b   = hk.Linear(output_units*n_components, name='l4')(net)\n",
+        "    c   = min_density_lower_bound + jax.nn.sigmoid(hk.Linear(output_units*n_components, name='l5')(net)) * (1 - min_density_lower_bound)\n",
+        "    p = jax.nn.softmax(hk.Linear(n_components, name='l6')(net))\n",
+        "    return MixtureAffineSigmoidBijector(jnp.exp(log_a),b,c, p)\n",
+        "\n",
+        "class Flow(hk.Module):\n",
+        "    \"\"\"A normalizing flow using the coupling layers defined\n",
+        "    above.\"\"\"\n",
+        "    def __call__(self):\n",
+        "      chain = tfb.Chain([\n",
+        "            tfb.RealNVP(d//2, bijector_fn=CustomCoupling(name = 'b1')),\n",
+        "            # tfb.Permute([1,0]),\n",
+        "            # tfb.RealNVP(d//2, bijector_fn=CustomCoupling(name = 'b2')),\n",
+        "            # tfb.Permute([1,0]),\n",
+        "        ])\n",
+        "      \n",
+        "      nvp = tfd.TransformedDistribution(\n",
+        "            tfd.Independent(tfd.TruncatedNormal(0.5*jnp.ones(d), \n",
+        "                                                0.1*jnp.ones(d), \n",
+        "                                                0.01,0.99),\n",
+        "                            reinterpreted_batch_ndims=1),\n",
+        "            bijector=chain)\n",
+        "        \n",
+        "      return nvp"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 27,
+      "id": "ylT0Cf7r8G0e",
+      "metadata": {
+        "id": "ylT0Cf7r8G0e"
+      },
+      "outputs": [],
+      "source": [
+        "model_NF = hk.without_apply_rng(hk.transform(lambda x : Flow()().log_prob(x)))\n",
+        "model_inv = hk.without_apply_rng(hk.transform(lambda x : Flow()().bijector.inverse(x)))\n",
+        "model_sample = hk.without_apply_rng(hk.transform(lambda : Flow()().sample(1024, seed=next(rng_seq))))"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 28,
+      "id": "-9ZOpqD28Gx1",
+      "metadata": {
+        "id": "-9ZOpqD28Gx1"
+      },
+      "outputs": [],
+      "source": [
+        "rng_seq = hk.PRNGSequence(12)\n",
+        "params = model_NF.init(next(rng_seq), jnp.zeros([1,d]))"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 29,
+      "id": "bjXg45N58Gu_",
+      "metadata": {
+        "id": "bjXg45N58Gu_"
+      },
+      "outputs": [],
+      "source": [
+        "# This the loss by NLL\n",
+        "# def loss_fn(params, batch, score):\n",
+        "#   log_prob = jax.vmap((lambda x: model_NF.apply(params, x.reshape([1,2])).squeeze()))(batch)\n",
+        "#   return -jnp.mean(log_prob)\n",
+        "\n",
+        "# This is the loss for score matching\n",
+        "def loss_fn(params, batch, score):\n",
+        "  log_prob, out = jax.vmap(jax.value_and_grad(lambda x, p: model_NF.apply(p, x.reshape([1,2])).squeeze()), [0, None])(batch, params) # Here we extract the grad of the model\n",
+        "  return  jnp.mean( jnp.sum((out - score)**2, axis=1))/1000 #-jnp.mean(log_prob) "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 30,
+      "id": "vKyWyEct8GsD",
+      "metadata": {
+        "id": "vKyWyEct8GsD"
+      },
+      "outputs": [],
+      "source": [
+        "@jax.jit\n",
+        "def update(params, opt_state, batch, score):\n",
+        "    \"\"\"Single SGD update step.\"\"\"\n",
+        "    loss, grads = jax.value_and_grad(loss_fn)(params, batch, score)\n",
+        "    updates, new_opt_state = optimizer.update(grads, opt_state)\n",
+        "    new_params = optax.apply_updates(params, updates)\n",
+        "  \n",
+        "    return loss, new_params, new_opt_state"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 51,
+      "id": "y8UW790jFjxK",
+      "metadata": {
+        "id": "y8UW790jFjxK"
+      },
+      "outputs": [],
+      "source": [
+        "learning_rate=0.0001\n",
+        "optimizer = optax.adam(learning_rate)\n",
+        "opt_state = optimizer.init(params)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 32,
+      "id": "cgpoNZNyFjrY",
+      "metadata": {
+        "id": "cgpoNZNyFjrY"
+      },
+      "outputs": [],
+      "source": [
+        "losses = []\n",
+        "master_seed = hk.PRNGSequence(0)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 52,
+      "id": "5sHvoJrgFjn6",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "5sHvoJrgFjn6",
+        "outputId": "5a072e32-06e1-4e75-a55c-00bf00b353fb"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "100%|██████████| 5000/5000 [01:16<00:00, 64.98it/s]\n"
+          ]
+        }
+      ],
+      "source": [
+        "for step in tqdm(range(5000)):\n",
+        "    batch, score = get_batch(next(master_seed))\n",
+        "    l, params, opt_state = update(params, opt_state, batch, score)\n",
+        "    losses.append(l)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 53,
+      "id": "7gzKKxIJ8GpA",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 282
+        },
+        "id": "7gzKKxIJ8GpA",
+        "outputId": "f5d39a64-c787-4d00-91ce-a92a220cb4b8"
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "[<matplotlib.lines.Line2D at 0x7f43d966d590>]"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 53
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXEAAAD4CAYAAAAaT9YAAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO3dd3wUZf4H8M+XJBACoUc6RARpKi2CKCoISPXAO89TT+UsZ+V33nl64imeIiCngu08FQQFe8F2IEoR6S1A6B0CIYQkBFIgJNlkn98fO7vsZnvfmXzer1demZ2ZzXxnd/PdZ555iiilQERE+lQr2gEQEVHgmMSJiHSMSZyISMeYxImIdIxJnIhIx+IjebBmzZqp1NTUSB6SiEj3Nm/efEopleJqW0STeGpqKtLT0yN5SCIi3RORo+62sTqFiEjHmMSJiHSMSZyISMeYxImIdIxJnIhIx5jEiYh0jEmciEjHmMSJKCat3J+PrNOl0Q4j5kW0sw8Rka/unrMRIsCRl0ZFO5SYxpI4EcUszlnjHZM4EZGOMYkTEemY1yQuIm1FZLmI7BaRXSLymLb+eRHJFpEM7Wdk+MMlIiJ7vtzYrATwd6XUFhFJBrBZRJZo215TSr0avvCIiMgTr0lcKZUDIEdbLhGRPQBahzswIiLyzq86cRFJBdALwAZt1XgR2S4ic0SksZvnPCAi6SKSnp+fH1SwRETkyOckLiL1AcwH8FelVDGAdwBcAqAnLCX16a6ep5SaqZRKU0qlpaS4nJiCiIgC5FMSF5EEWBL4J0qpbwBAKZWrlKpSSpkBzALQN3xhEhGRK760ThEAswHsUUrNsFvf0m63mwHsDH14RETkiS+tU64BcBeAHSKSoa37J4DbRaQnAAUgE8CDYYmQiIjc8qV1ymoA4mLTj6EPh4iI/MEem0REOsYkTkSkY0ziREQ6xiRORKRjTOJERDrGJE5EpGNM4kREOsYkTkSkY0ziREQ6xiRORKRjTOJERDrGJE5EpGNM4kREOsYkTkSkY0ziREQ6xiRORKRjTOJERDrGJE5EpGNM4kREOsYkTkSkY0ziREQ6xiRORKRjTOJERDrGJE5EpGNM4kREOsYkTkSkY0ziREQ6xiRORKRjTOJERDrGJE4BKTNVYczba7AtqzDaoRDVaEziFJCd2UXYllWISQt2RzsUohrNaxIXkbYislxEdovILhF5TFvfRESWiMgB7Xfj8IdLRET2fCmJVwL4u1KqG4CrADwqIt0ATACwTCnVCcAy7TEREUWQ1ySulMpRSm3RlksA7AHQGsAYAHO13eYCGBuuICl2KaWiHQJRjeZXnbiIpALoBWADgOZKqRxt00kAzd085wERSReR9Pz8/CBCpVgiEu0IiAjwI4mLSH0A8wH8VSlVbL9NWYpjLotkSqmZSqk0pVRaSkpKUMESEZEjn5K4iCTAksA/UUp9o63OFZGW2vaWAPLCEyIREbnjS+sUATAbwB6l1Ay7TT8AGKctjwPwfejDo1jHGnGi6Ir3YZ9rANwFYIeIZGjr/glgGoAvReQ+AEcB3BqeECk2sVKcKBZ4TeJKqdVw/x87OLThEBGRP9hjk4hIx5jEKShsJk4UXUziFBC2EyeKDUziREQ6xiROQWFtClF0MYlTQFibQhQbmMSJiHSMSZyISMeYxCk4bGNIFFVM4hQQYRtDopjAJE5EpGNM4kREOsYkTkFhjThRdDGJU0BYI04UG5jEiYh0jEmcgsIWhkTRxSROAWELQ6LYwCRORKRjTOJERDrGJE5BUWxkSBRVTOIUEDF4I8PSikrsPVkc7TCIvGISJ3Lh0U+2YPjrq1Bmqop2KEQeMYkTubDxyGkAQKWZ1UUU25jEKShsJ04UXUziFBC2EyeKDUziRB4oXmpQjGMSp6AYNcdx0gvSCyZxIiIdYxInItIxJnEiF1gXTnrhNYmLyBwRyRORnXbrnheRbBHJ0H5GhjdMIiJyxZeS+IcAhrtY/5pSqqf282NowyKKLt7YJL3wmsSVUisBnI5ALERE5Kdg6sTHi8h2rbqlsbudROQBEUkXkfT8/PwgDkdERNUFmsTfAXAJgJ4AcgBMd7ejUmqmUipNKZWWkpIS4OEoVhn99p/Rz4/0L6AkrpTKVUpVKaXMAGYB6BvasCjWGb3K2OCnRwYSUBIXkZZ2D28GsNPdvkREFD7x3nYQkc8ADATQTESOA/gXgIEi0hOWq81MAA+GMUaiiGM1CumF1ySulLrdxerZYYiFdIidYoiiiz02KSBGn57N2GdHRsIkTkSkY0ziREQ6xiROATF6E0MivWASJ/KA920p1jGJE7nCKw3SCSZxCophS6pGPS8yHCZxCkhNqROvKedJ+sUkTuSBYa80yDCYxIlcYQmcdIJJnIKiWHlMFFVM4hQQo3e7J9ILJnEiT3ihQTGOSZyCYtQbf7zOIL1gEqeAGL3pnUG/m8iAmMSJPDH4lxXpH5M4kScsklOMM1wSN5sVzpyriHYYNYZRcxwL4KQXhkviryzeh14vLsFpJvKQem3JfnSd+JPtMZMchdo3W47j8S8zoh2G7hguif+88yQAMImH2BvLDuC8qSraYZCBPf7lNnyzJTvaYeiOLpP48TOlKCo1RTsMIqKo01USV0qhotKMAf9ejsEzfo12OATjz3bPYQUo1sVHOwB/TF64B7NXHwEAnDrrprqElbURYfR24kR6oYuSeF5xGbYeO2NL4FbL9+ZFKSKqKThGDMU6XSTxa19ejpv/u9Zp/T0fbsJ7Kw5FISIiotigiyReXml2u23WqiNutrAuMxKM/iqzTpxinS6SuCdVZscEz4vfSDH2Ky2s9CedMEASZ0mJiGou3Sfx4rLKaIdQs/E7lCiqdJ/E3TF48+Woqym1DfwcUazzmsRFZI6I5InITrt1TURkiYgc0H43Dm+YFE2xUmWVW1yG/JLyaIdBFFN8KYl/CGB4tXUTACxTSnUCsEx7TAY1bs5Gp3XRKKH2m7oMV05ZGtFj1pQrDtIvr0lcKbUSwOlqq8cAmKstzwUwNsRx+aXCrgnisdOlUYzEmFYfPBXtEIjIjUDrxJsrpXK05ZMAmoconoAUll7ogm+qshQRY6MCwLhYQg2tvSeLsftEcbTDIB0K+samsoyA5DZnisgDIpIuIun5+fnBHs6l7zNOhOXvkjOjD3hVXaROd/jrqzDyzVWRORgZSqBJPFdEWgKA9tvtICZKqZlKqTSlVFpKSkqAh/Ps/dWHw/J3yVlNyeG80iC9CDSJ/wBgnLY8DsD3oQknMLnFzi0WakqyiTa+zETR5UsTw88ArAPQWUSOi8h9AKYBGCoiBwAM0R6HTYsGiX4/h2NehIf1VWVBlSg2eB1PXCl1u5tNg0Mci1u1AsgYZvdjZlEQLHXiNSeFsyhAsU4XPTYDGYxoxf7w3ESt6aontZp2o5Mo1ugkiTuvqx3vGPot7ziON775aPWm7RQK1pzNUf4oXFgw8I8ukvgHf7rStnx737bIeG4oJo7q6rBP+tEzDo9jpau40fBeA/DSj3vwty8yoh2GYTGH+0cXSbxT82T8/NfrUL9OPP4yuBMaJdXGXf1TPT6HOZxCwVWp8L2Vh/Ht1uwoRFMzmJnF/aKbiZI7t0jGzheGedynzFRlW+YHITyqv6xGfZVZWRQ9Rv1MhYsuSuK+6jLxJ9syc3h4GT3JnSk1AQDO2xUMKDL4v+sfQyVxe6wTD4+a9g92KP9ctEOocXgV7R9dJ/GxPVu53VZ43hTBSGqOmnZjky0lKNbpOomPv6Gj2217cjgiXDhcaGJo+W30UlOrRnWjHUKNY/CPVMjpOokbv2Y2don22hv1H65lQ8tQD0m146IcSc1j9IJBqOk8ifPNjjTb2Cna96dR/99qibG/pGIZX3L/6DyJe1bGlgUhV72O2Kh1xjWluigWGfUzFS66TuJtGid53J5ZwJYFoVb938uojYAuJPHoxlET7c8tiXYIuqLrJJ6Y4Lm+shbH9wg5VW10SLNS2HjktOFKT9Y6f2tT1cLSCoz/dAuKy9jqKdy2ZRVFOwRd0XUS9+ZUifNkERSc6k0M80rKcet76/DR+qNRiig8rBNuD5mxAgDwzopDWLA9Bx8b7DxjUVklq0H9Yegkfsf7G6IdguG4q144lHc2soFEmNFb48SS9Mwz3nciG0MncQo9dzf6jJ7bWDMXOQ3rJkQ7BF1hEie/7Djuur7S6K04rDncaHX/sahuhNrmG+W9NHwST8/k5BChtPWY60tdg/w/uMV245Hz6YZjYT9G6oSFuH9uetiPEwm6T+I///U6j9tveXcdDuefRWFphW1dXnEZiji2SkDc5TCj57ZINTk0SulQD5btzYt2CCGh+yTeuUWy131umL4CQ19baXvcd+oyXDPtl3CGZViFpa6//IyefGzVKWH+ujL4y0hhoPsk7qv8knLklZTZkvfZ8kp8vP4oTFVmp32LSk249uVfsOsE26tW564pYSSTT8HZclS6eN/CKkLVKVXM4uSnGpPEAaDvlGXILjxve/zsdzvx5FfbcOZchUMX/bWHTiHr9Hm8texgNMLUpUjmnj6Tl+LFBbsjd0AAtaxjxYT5OBwHn/xliCT+5YP9A37udxkn0OvFJfjj+xswZ/UR/LTzpG0m9yqlsDO7CAcN3ga6uuIyE06d9a+jVDirGYrLTLZON1aLdp4M2/FcudBO/MJ5huNqYO9Jdjkn/xgiife9uEnQf2Pz0TOYtGA3Hvp4M+K0YpfZrDD6rdVOCcTo+k1ZhrTJS/16TjgLkGsPFjh9kUa6wOpq1MYbpof+c8FB28hfhkjiobbhcAEA5/rJ1AkLkTphYTRCiqhA5pWMfFVuZA/o6samtWu+K3tyigNqAVVeGeG6ftI9JnEX3l99BACQW3yhSuH7jGzbclGpCZMX7Ma58kqf/l5FpRl7Txp7pqFwVqe46i0Z6S+NWrX8u7E54o1VuH3mer+PY2ISJz8xiXtgP8XbY59n2JZ7TFqM91cfQfd//YyDeY51mEWlJqdL4skLd2P466uQ5aHkBgBHTp1DRlZhCCKPPHMY6zdc3ZOIZA5PnbAQucVlAIBVB075/LzdAUwRyJI4+cswSfx3vdtE5bhDZqxEYWkFhr++El9uykKPSYtxxQuLcba8EqUVldh9ohibj1p6ORacq/D4twa9+ivGvr0mEmGHXGUYk/grP+9zWhfpdunz1lmaVu7IDm+z03MVvl3dEVkZJom/OLY7Zt2dZnvcvVWDiB2756Ql2HuyBP+Yvx2ApfqkxwuL8ed56Rj55irsOmEpkel1fJHqN47ztFKpvQXbcyIVDgDgjJtOR5F2wq7Jaii8vZzNWsk/hkniSbXjMbRbc9vj/40fEMVoLO191xwscFpXdN7ktVrFXyVlprBWw1QfVe5gfmw0uSzw0Awyr7gM24+Hv2rq6mm/4PiZ0L2fuS6+IIk8CSqJi0imiOwQkQwRianRZKw3omJJTlEZRr25Cte+vDykf/fBjzZj7NtrwtY8Lb7aa3nHrA1Yd7jAaT9PSTUcXJXG1x48hYGvLMfV037Bb/4TmaqpAf8O3ftZZmKdOPknFCXxQUqpnkqpNO+7ht9verTCzLv6RDsMl7JOl+L4Gcvld3m12Uv22XXySJ2wEFMW7va5ido2rRTuaggBwHJjMJAZac5XWGJ0NQ3eP77e7rTu9++t8/sY3uQUeaqucK6emrRgNzILSsNaR++N0ceRodgSH+0AQu3N23vZltc9fQMe+mgzzCr8N6R8YX+D7qGPNmPKzZcj63QpZq06gqLzjjc9Z606glmrLE0dNz0zBJsyTyMluQ5aN6qLVo3qAgDun7sJ3Vs1tF11FJytgFk5Vn8s35eHez7YBAC486r2bmO76a3V6JBSD2/cduH1e+fXg3j8xs4+n9/h/NBPTP3EV9vcbnOVKyUGZm9gDqdICjaJKwCLRUQBeE8pNbP6DiLyAIAHAKBdu3ZBHs4/LRvWxfda3XisddJZvi8fV/s4kuKVUxx7Tz49ogt6tWuMpXvysHTPheE0B776KwDgudHdcO+Ai1FwttyWwAFLM0B31Uw7souwI7vIIYmbYmAcj8oq/2KIfgo3/rC84dKyYSJyipzvCRSWVqBRUu0oRKQPwVanDFBK9QYwAsCjIuI0uLdSaqZSKk0plZaSkhLk4QL35DDfS5Sx7qVFe3Grh6qLSQt2Y8H2E/hwbabD+tOlFUidsBC/7M0FAMxefQRvLjvg9u9UxECb5VoeStaukmWlOfoxszolMPFxrt/r5fuMMe53uARVEldKZWu/80TkWwB9Aaz0/KzoeHRQRzw6qGPMlcjDZfynW53WWcdDufdDx3vQo65oaVu+e85G2/Ls1UcwcXQ3v5JS6oSFqJsQh03PDkH9OsHX1nmqHXHVZHN/rv8tZ3ZmF6Fd0yQ0SAzN3I4xcAGjSwm1XJcpPX2RUxAlcRGpJyLJ1mUANwLYGarAwiVz2ijb8n0DLo5iJLHj719eqHdeuT8/6L933lSF/bmhGY3P0/+vhKjyZPRbqzHO7ssrWOGeOMKo2jZJcrk+Fu5zxLJgikrNAXyrvcDxAD5VSv0UkqjCbOcLw5AQJ6gTH4cJI7rgxtdW4rHBnZCRVehUBVETeGpjPkrrrNS+aRKOFvjeHvq2mevxzcNX47LWDYOKLVSJ2h3rVcbWY8G1KVdK2ZINa1MCk5Jcx+X6GGwtHFMCTuJKqcMAeoQwloixv8xPiKuF5U8MBACM7dW6RiZxT6y9Tf1VUWnG6LdWY/VTg9CmsesSli88FcJCUeK1Vn0EW9g7b6pCUu147W8yi4cSq1M8M0yPzVCZ//DVWPf0DWhW3/lueOa0UcicNgpz7+0bhcj0acC/l+OMlzFjPPE04FQocqV1Jp04F4kiwc2NNlcy7ErygdSJXx7kFYvR2PdcPVTDJmXxF5N4NX3aN0bLhnWR/uxQZE4bhVv6WAbWsm/dcv2lKch4bih6tm0UrTAjzp+qlOp6vbjEp/2GzliBl3/aG/BxAmEtNVfvHNS6UV2M6dkaWyYOdftc62cDAB774sIol4G0Tqlb27lDVU121m6Y5+lL9kcxktjHJO5FI63jzMXN6jmuT6qN7x69Bk3r1Zz2q/Zj0/jLl1ZBB/LO4r+/Hgr4GIHwNqdlEw/v761pbW3L+SUXhhwIpJUj630dDQ7DrElGxSTuxRPDOmPSmO4Y3r2Fy+1Pj+wKAJj/cH88O6prJEOLuGDzzLg5G9Fl4iJc/vzPIYkn0EmFD+efxXsrLF8WvtRfj7q8pcv1vdq5vhJjnThFEpO4F4kJcbi7f6rbno639GmD/ZNHoE/7Jrj/2g629fZNGY3i2VHdMLBz4B22VuzPR5nJjJKySiilMHv1ERSWVuCXvbn4bOMx235lpiqfxo353/YTAcVx28z1eGnRXpSUmdyWmu2rRF763eUu90mIc/3vwyQeGL5sgTHc2CnRUDv+wj/zD+Ovwc5sS4uO9U8PhohlLkZTlRl3zNoQrRBDol3TJHx4T1/0nbIUeSXBjVj49y+34Zut2Zj64x6nEnWXiZaWqt6+CF31KE1r3xjp2iQc7ljnEDWbnedRtWf92va1E1BucRmaN0hkK/EwevXnfdiadQaf3H9VtEOJGUziIXZFm0a4oo3lMrtFw0QAQPMGlt9DujbH0j25WPr4deh4UTIA4JMNR7E58wzaN62HwvMVeOj6S9Bv6jIAwAd/uhIr9udjd04xrrmkGV5bGhs3eObe2xe3vLMW5yoCH/r2m62WOUsDrRIBLKM2rjl4Cl1aJKNpfUsbY28JHADitKsqs1IhLTVb3zf7QdgC4WmMm5ruP5w0wwmTeAS9P855tN4/9muPP/ZzHF1w74vDUWaqQqOk2hjU5SLb+ib1EjDx+10O+z5x46V4dbFjcn986KWYEcY7+l1bNsCuScPxxaZjeGr+Dkz77eWY8M2OkB/njaXux3UBgI/XH8PH64+h40X1sfTx633+u9Z2x1VKBT036FPDu+Df1VrU/OWzC0MeTF6wG8+O7ubX3/x6y3GHm6ZWZ85V4M1fDuCfI7u6rcqhmoefhBiUmBDnctS2u/qnYsH/WUZlvPqSpvj4vn54eGBHTL35coy4rAVu6tEKh6eOxF8Gd3JbFWFt6z7bxReKv/5wZTtkThuF2/q2w5K/OY19FjRfrzzsJ1K2r9oCXDf3syZxS0k8iAAB3Dsg1eP291cfQamf82a6GqsdACYv3IMP1mTixx2RnQqPYhuTuM5c1rohMqeNwqd/vgoDOjVDXC3BHf3a4Z07++Ct23s5XIZbE+tve7dGWvvGaN7gQrfmwV2b2xJ65rRR6N+hKQBg+u974NtHrvY7rk7Nk7F70rAgzy541VsRuaotsb5EnurEq6+d/3B/l61R6sR7b99901urve7jC2vVTzBVUGQ8rE4xsE7Nk7H6qUFo1bCu1zrWD+65EmfLK9FMq1v+6qH++P27/s3Uk1Q73nYF8N9fD+Lln5xnqY+04jKT01WN9absrhNFuLR5stvn2nfi7NO+Cb595JqARsE8lH8OlVVmxAdZBWINx0g5fH9uCRolJeCi5ESP+50rr8T1r/xqe1xcZgrZqJN6x5K4wbVpnOTTTbLEhDhbAgcsrTyeHtEFGc+577HoySMDOwb0vFDzNALemoMFESvVdnxmUUBT5Nm7MMCW/rN4RaUZZrPCja+txNUveZ8cZciMFThlN4frgRCNkmmE15JJnFwSETx4/SW6m1Gl+r/k3pxiLN2d63Jfs1Iemxi6suP5GwOMDHj2u50+30h1Nem09fsoGnmnvLIKS9y8jr5Izzxt+8KsrDLj0mcXYZRWzWQd8kBBobU29WB11Wf8cTXvayCMUDXFJE5eHZo6EoemjvT7efsmD8fd/d3P6xkJf5i5HvfPS3e73d/WKcmJCbb7CIHo8M8f0XXiT15LgH0mL3VaZ72miMZ45S//tA9/npeODYcL/H7uukMFuOXddXhX6yVrTdp7cpxHyPR1wMJaIijUZqqaty4Tpiqzw2Tjvio1Bd5MNlYwiZNXcbXE1rbaH3Xi4/BnrReruy7q0VRlVg4DX9knVn9Ku7te8O+G7nlTFSZ+vxOrDuQjdcJCvLZkP86bzOh0UX2Pz7MmuGgUHo+fsQyAdqbU/xEpswvPA7gwGmEoRpYd8cYqHDttiem573dh6o97MOz1lTjm50Bt1uEX9IxJnMKqbZMkHHlpJL595BrsemEYFoehKSIA5JWU4ctNWfjfNtdd8ctMVZi7NhMntIQCAB+tP+owEfPiatUFvk5IUS+Aaeg+Xn8Md822zCb0xrID2JZV6NTx6M1lBxyqVQ5oSXDKwj0AgKzTpU4l+tPnKvD8D7t8mh+1yqx8rk6wta0PYHAv69WOrx2Y7rkm1af9fvOfNbblD9ZkAgCOF5biXHklyiurUGaq8nqldfzMeY/b9YCtUyjsrDfk6tWJx6XNk/HKLVfgSa0tdJcWydgbwGVwdX2nLPO43dqV336MFgAw2Q2e8uBHm7H3xeGIryU452fb7rn39g16irdD+eccHs9Yst/WaevJYZ1tsw+dLa/EU19vxxfpWfhd7za4qkMTdEiph9zicjzyyRYAQI+2DdGtZUNc2ry+w83dLG0IiA/WZOKHbSdwvqIK+6eMQJVZoZbA1gv3ZNF5pNRPRMOkBNzw6q84fMoS25ZjZxzmZPWFtZ3815uP49Xf9/B6lfOvm7rbkrK/qg9tcXf/9pg05jK3+7uqgskvKceJwvPoUW2o6fdXHUaDxASkpTZGhxTPV02RxCROEXdtJ8sgWvMf7o9ebRujwz9/9Ov5797ZGw99vCWgY1f/wvjtf9c6PJ6xZD9mrjzs99+9/lLLOfVq1wjv3dUHj32WgZGXt3DqYRuoV352bK75RXoWAGD+luOYv+W40/5/++LCvKm/79MGN3ZvgbySMjzzrfM0uKsPnMKds12P65M5bZQtgQOWybMnjOgCADhZVIY2jet6nQNzXbV6dF+qqv4xvHNImqjOW3cU89YdxcDOKZh1dxqKzpscWmG5KkD0nboUSlluYifbNWOcrF0BAbE1wJ1EsolNWlqaSk93f5OJaracovO4KDkR323Nxt+/2uZ2v1+fGIiBr/4a9nh+27s1Ztza06/n2M+1Cfg2jrreDejYDB/f3w/FZSYcyT/nVIK9feZ6h0S+deJQp4lC3rq9F/7vs624KLkONj4zBICluucSP7/gPfltr9b4Zms2Dk4ZgY7PLHLYNn5QRzyhTfxifc9e+E133NGvHT7dcAx/7NfO4Tmzx6UhLbUJqszKYcz5eesyMW/dUb+GgfCFiGxWSrnsZs0kTjHpbHklLvuX63HHM6eNilhyDLbE9f6qww4lOG9qx9VCRSAVzzFo9BUt0e/iJk5XI0sfvw5DZqx0+ZyEOMGBKRdaQpVXVqHzs9Gff/3JYZ2droasdk8ahqTa8diWVYgxb1vq6a2fm9KKStSOqxV8Ry8PSZw3Nikm1fdys9B+arRYdv+1HfDEjZf6vP+jg2Kjk1QoLNie47I6yV0CBwBTlWOh0pdhDSLBXQIHgM83ZiF1wkJbAgcspfkP1xxBt+d+RsdnFuGlRb5/kfuLSZx06eZeraMdgs/G39DJ530fHnhJGCPRp8xpo/DGbf5Va0XSpAW7Xa5//n8X1r+34jAKA2ie6QsmcYpZ+yePwEf39cWhqSNt7cyv7dQMgGUURz1Z+eQgTBzdDUdeGolGSZabZf+5o5dD+/uBnVNQO74WFj12bbTCjFljera2dbIKpM9CLAh22AV3WCdOumA2K7z5ywH8sV97pCRbWheUVlRi8PQVTl2yb7uyLT7flBWS40ajFYKn+wE1gbfXvMxUhXPllXjl5334fFMWlj5+PYbMiP2Jla/q0ASfP9A/oOfyxiYZWlGpCT0mLcZNPVrhqeGd0aZxEtYdKsDctZn4addJt89rkBiP4jJLG+a1E27A1dMcB2KaPPYy3HlVdIcNUEqhvNKMMlMV9ueeRd+Lm9i2GbXlS6BfnPtzSxBXSzB4emwm9HH92+MFD23WPWESpxrrROF5FJaa0K1VAwBASZkJaw8VYEjX5k6X5WazwkuL9uDOqyyHDJEAAAcHSURBVNrjouRE1K0dGzfV3DFVmXGyqAxtmyRh5f58pCTXQdeWDWzbi86bUHC2HG2bJOEvn23FFW0a4ZqOTdEhpT5WHziF3TnFuP/ai3GsoBSXtW6Ir9KzkJyYgPZNk/Dwx5sx/daeuKJNQ3TSmtYtf2IgBkWgaWewVz8ZWYWoVzsOQ1+z3EAVcd02/Yfx1zj0+gy39U8Ptk3Z6C8mcSIKqXPllcgvKUdqs3oAgOV781BSXomzZZUY3aMlGiQmwGxWto5c1l66/7qpGxIT4lBuqsLoHq2QEFcLt767DmN7tcbGIwWY86crvXYe8lVllRm7ThSjR9tGeOKrbbg1rS12nSjCpszTSEyIw4xbe2LfyRIUnC1Hvw5N8d/lBzFd6yE7tmcrfJdxAldf0hR7T5bg9Lngb0oG8+XEJE5E5IPMU+dwurQCvds1drm9vLIK27KK0KBuPLq0aOC0vbLKjI2Zp9G9ZUPMWnUYPds2QmbBOYzt1dqhp6i/mMSJiHSMnX2IiAwqqCQuIsNFZJ+IHBSRCaEKioiIfBNwEheROABvAxgBoBuA20WkW6gCIyIi74IpifcFcFApdVgpVQHgcwBjQhMWERH5Ipgk3hqAfbe449o6ByLygIiki0h6fn5+EIcjIqLqwn5jUyk1UymVppRKS0lJCffhiIhqlGCSeDaAtnaP22jriIgoQoJJ4psAdBKRi0WkNoDbAPwQmrCIiMgXQXX2EZGRAF4HEAdgjlJqipf98wEEOh5jMwCnAnxurOG5xB6jnAfAc4lVwZxLe6WUy/roiPbYDIaIpLvrsaQ3PJfYY5TzAHgusSpc58Iem0REOsYkTkSkY3pK4jOjHUAI8Vxij1HOA+C5xKqwnItu6sSJiMiZnkriRERUDZM4EZGO6SKJ62HIWxHJFJEdIpIhIunauiYiskREDmi/G2vrRUTe1M5nu4j0tvs747T9D4jIuAjFPkdE8kRkp926kMUuIn201+ag9tzQzL/l+7k8LyLZ2nuTofVvsG57Wotrn4gMs1vv8jOndW7boK3/QuvoFo7zaCsiy0Vkt4jsEpHHtPW6e188nIse35dEEdkoItu0c3nB0/FFpI72+KC2PTXQc3RLKRXTP7B0JDoEoAOA2gC2AegW7bhcxJkJoFm1dS8DmKAtTwDwb215JIBFAATAVQA2aOubADis/W6sLTeOQOzXAegNYGc4YgewUdtXtOeOiPC5PA/gCRf7dtM+T3UAXKx9zuI8feYAfAngNm35XQAPh+k8WgLorS0nA9ivxau798XDuejxfREA9bXlBAAbtNfQ5fEBPALgXW35NgBfBHqO7n70UBLX85C3YwDM1ZbnAhhrt36eslgPoJGItAQwDMASpdRppdQZAEsADA93kEqplQBOhyN2bVsDpdR6Zfn0zrP7W5E6F3fGAPhcKVWulDoC4CAsnzeXnzmtpHoDgK+159u/LiGllMpRSm3RlksA7IFllFDdvS8ezsWdWH5flFLqrPYwQftRHo5v/359DWCwFq9f5+gpJj0kcZ+GvI0BCsBiEdksIg9o65orpXK05ZMAmmvL7s4pls41VLG31parr4+08Vo1wxxrFQT8P5emAAqVUpXV1oeVdgneC5ZSn67fl2rnAujwfRGROBHJAJAHy5fiIQ/Ht8WsbS/S4g1ZDtBDEteLAUqp3rDMdPSoiFxnv1Er7eiyPaeeY9e8A+ASAD0B5ACYHt1wfCci9QHMB/BXpVSx/Ta9vS8uzkWX74tSqkop1ROWkVv7AugSzXj0kMR1MeStUipb+50H4FtY3txc7bIV2u88bXd35xRL5xqq2LO15errI0Yplav945kBzILlvQH8P5cCWKop4qutDwsRSYAl6X2ilPpGW63L98XVuej1fbFSShUCWA6gv4fj22LWtjfU4g1dDghH5X8ofwDEw3Iz5mJcqOjvHu24qsVYD0Cy3fJaWOqyX4HjTaiXteVRcLwJtVFb3wTAEVhuQDXWlptE6BxS4XgzMGSxw/kG2sgIn0tLu+W/wVIXCQDd4Xhz6TAsN5bcfuYAfAXHG1iPhOkcBJZ66terrdfd++LhXPT4vqQAaKQt1wWwCsBod8cH8Cgcb2x+Geg5uo0pnP9MIXzhRsJyR/sQgGeiHY+L+DpoL/Y2ALusMcJS97UMwAEAS+3+eQSWSaYPAdgBIM3ub90Ly02OgwDuiVD8n8FyOWuCpQ7uvlDGDiANwE7tOf+B1lM4gufykRbrdljGvLdPHs9oce2DXesMd5857b3eqJ3jVwDqhOk8BsBSVbIdQIb2M1KP74uHc9Hj+3IFgK1azDsBPOfp+AAStccHte0dAj1Hdz/sdk9EpGN6qBMnIiI3mMSJiHSMSZyISMeYxImIdIxJnIhIx5jEiYh0jEmciEjH/h8FSPR4Ih733QAAAABJRU5ErkJggg==\n",
+            "text/plain": [
+              "<Figure size 432x288 with 1 Axes>"
+            ]
+          },
+          "metadata": {
+            "needs_background": "light"
+          }
+        }
+      ],
+      "source": [
+        "plot(losses[:])"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "x = jnp.stack(jnp.meshgrid(jnp.linspace(0.,1.,128),\n",
+        "                           jnp.linspace(0.,1.,128)),-1)\n",
+        "\n",
+        "im0 = jax.vmap((lambda x: model_NF.apply(params, x.reshape([1,2])).squeeze()))(x.reshape([-1,2])).reshape([128,128])\n",
+        "contourf(x[...,0],x[...,1],jnp.exp(im0), 100); colorbar()"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 286
+        },
+        "id": "Q4qGTfhFvKtp",
+        "outputId": "d5e9bad0-126f-4a8c-a615-8c225907e5eb"
+      },
+      "id": "Q4qGTfhFvKtp",
+      "execution_count": 56,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "<matplotlib.colorbar.Colorbar at 0x7f43d8c468d0>"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 56
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXAAAAD8CAYAAABuHP8oAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO3de5QjZ3nn8e9PVbp093TPrX3BngEbMASvSQz4GBLCLdyMN8dmEw6xWRIgdrxOICGBhEDYBY7ZzYFkCYETLzAxXkiWAA4JZJYYjElwfEJirwd8N7exMfaML+PxXDwz3a1L6dk/qqSuVksttVo9XWo9n3N0RiWVpLdmen56+6m33ldmhnPOueGTW+sGOOec648HuHPODSkPcOecG1Ie4M45N6Q8wJ1zbkh5gDvn3JDqGuCSrpa0T9JdHZ6XpI9L2i3pDknPHXwznXPOteqlB/4Z4Lwlnn8NcEZyuwz4xMqb5ZxzrpuuAW5mNwIHltjlQuCvLHYTsEnSkwbVQOecc+2FA3iPU4EHU9t7kscebt1R0mXEvXQCgueNMzWAj3fOrXdHOLjfzE5YyXu8+mXjtv9Avad9v3tH+TozW6rykAmDCPCemdkOYAfAlLbY83OvPJ4f75wbUt+sX/OTlb7H/gN1br5uW0/75p907/RKP+94GMQolL3A9tT2tuQx55xzq2gQPfCdwNskfQF4PnDYzBaVT5xzbi0ZRtmqa92Mgeoa4JI+D7wUmJa0B3g/kAcws08C1wLnA7uBGeAtq9VY55xz87oGuJld3OV5A946sBY555zryXE9iemcc2uljjFn0Vo3Y6D8UnrnnBtS3gN3zo0EA8rW2zjwYeE9cOecG1Ie4M45N6S8hOKcGwl1M+bW2SLu3gN3zrkh5T1w59xIMETVtNbNGCjvgTvn3DK1W+hG0p9K+n6ysM2XJW1KHt8q6VuSjkr6iyXe8wOS9kq6Lbmd360dHuDOObd8n2HxQjfXA2eZ2U8DPwTekzw+B/w34Pd7eN+PmtnZye3abjt7CcU5NxIMmLNgMO9ldqOk01oe+0Zq8ybgdcnjx4B/lfT0gXx4ivfAnXNu8H4d+Fofr3tbUoK5WtLmbjt7gDvnRkIdMWdhTzfi2Vd3pW6X9fo5kt4L1IDPLbOJnwCeBpxNvKLZR7q9wEsozjm32H4zO2e5L5L0ZuAXgZcnM7X2zMweTb3PXwJf7fYa74E759wASDoPeBdwgZnN9PH69GLw/wm4q9O+Dd4Dd86NhLiEkh/Ie3VY6OY9QBG4XhLATWZ2ebL//cAUUJD0WuBVZnaPpKuAT5rZLuBPJJ1NfL71fuC/dGuHB7hzzi1Th4VuPr3E/qd1ePzS1P1fXW47PMCdcyPBTI0TlOuG18Cdc25IeYA759yQWl+/TzjnXAfxSczCWjdjoLwH7pxzQ8p74M65kWCIufpghhFmhffAnXNuSHmAO+fckPISinNuJAzySsys8B64c84NKe+BO+dGQt38JKZzzrmM8B64c24kmNfAnXPOZYUHuHPOLVOyZuU+SXelHtsi6XpJP0r+3Jw8vlHS/5V0u6S7Jb2lw3s+T9KdknZL+riSScWX4gHunBsJdUS5nu/p1oPPAOe1PPZu4J/M7Azgn5JtgLcC95jZzxAvAvERSe0mZfkE8BvAGcmt9f0X8QB3zrllMrMbgQMtD18IfDa5/1ngtY3dgcmkR70heV0t/cJkObUpM7spWUvzr1Kv78hPYjrnRoKZqFrQ6+7TknaltneY2Y4urznJzB5O7j8CnJTc/wtgJ/AQMAn8ipnVW157KrAntb0neWxJPfXAJZ0n6QdJbebdbZ5/sqRvSbpV0h2Szu/lfZ1zLqP2m9k5qVu38F4g6UU3VqV/NXAbcApwNvAXkqYG0ciuAS4pAK4EXgOcCVws6cyW3f4rcI2ZPQe4CPhfg2icc84NkUcbK8snf+5LHn8L8PcW2w38GPipltfuBbaltrcljy2plx74ucBuM7vPzCrAF4hrPWlGvOIywEbiXxWccy4zGtPJ9nLr007gTcn9NwH/kNx/AHg5gKSTgGcC9y1oW1x6eULSC5Ja+a+lXt9RLwF+KvBgartdbeYDwBsl7QGuBX673RtJukzSLkm7qpR7+GjnnMseSZ8H/h14pqQ9ki4BPgS8UtKPgFck2wAfBH5O0p3Eo1P+0Mz2J+9zW+ptfwu4CtgN3At8rVs7BnUS82LgM2b2EUk/C/y1pLNaC/VJHWkHwJS2WJv3cc65VREPIxxM5JnZxR2eenmbfR8CXtXhfc5O3d8FnLWcdvTSA98LbE9tt6vNXAJckzTi34ESML2chjjnnFueXgL8FuAMSacng88vIq71pKVrPM8iDvDHBtlQ55xzC3X9fcLMapLeBlwHBMDVZna3pCuAXWa2E3gn8JeSfo/4hOabk2E0zjmXCWYMrISSFT0djZldS3xyMv3Y+1L37wFeONimOeecW8r6+jpyzrkOBnkSMyt8LhTnnBtSHuDOOTek1tfvE84514GZl1Ccc85lxPr6OnLOuQ4MUfEeuHPOuSzwAHfOuSG1vn6fcM65DsxEJVpfkec9cOecWyZJb5d0V7LK/O+2PPdOSSap7YR+kiJJtyW31nmllmV9fR0551wHdaBS73lNzI4knUW8evy5QAX4uqSvmtluSduJp459YIm3mE1PI7sS3gN3zrnleRZws5nNmFkN+Bfgl5LnPgq8i/n1MFeVB7hzzi023Vg9LLldlnruLuBFkrZKGgfOB7ZLuhDYa2a3d3nvUvKeN0l67Uoa6SUU59xIiMeB91xC2W9m57R9H7PvSfow8A3gGPGK80Xgj+iw8k6Lp5jZXklPBf5Z0p1mdm+vDUvzHrhzzi2TmX3azJ5nZi8GDgJ3A6cDt0u6n3jlsu9KOrnNa/cmf94H3AA8p992eA/cOTcSzKASrfwkJoCkE81sn6QnE9e/X2BmH0s9fz9wTmPx4tTjm4EZMysno1ReCPxJv+3wAHfOueX7O0lbgSrwVjM71GlHSecAl5vZpcQnQD8lqU5cAflQsiBOXzzAnXNumczsRV2ePy11fxdwaXL/34BnD6odHuDOuZFgiKi+vk77eYC7gcnle/9xqldrq9gS50aDB7jralEwh/Pbyuf7es9gDKxaXfhgbXGoe9C7QTGD6gCuxMwSD3DXVjO0k7BWPo8awR0GEATxn6l9epIKadWi+E6U/FmLsOT5Rrinf+H1MHduIQ9wBywM7GZYN4K6VIQgwEp56sU89VKABTnqhRz1QFioBe9lQbytaOHVxKrF27nIUM1Q3VBUj+/X6iiK4j/nqiiK4rCvRRBF2Fx5vteehLwHuht1HuAjrG0vOwlrSkWsWKA+UaReCojGQmrjAdVxURsT9byojYHlICrEb2Op304VLb6fi0D1eFtRvJ2rGoogqBhB2ZI/6+QqdYJjVXLlahzoxQLUIlSuYLUaVq02e+ce5K4XhqgOaBx4VniAj5iOPe1iAZsYp14KqU2VqI0FVCcDKpOiOiGqE1CdhGjMqE9EUIwICnXCQo0gVweg0Q9vnOmvR61/zvfULRKYsEiokkNVkavkCGZFUIZwFvLHSuSPGeFMncKRiGC2RnCsQu5oGZXLUK5gc2VyYdwr9yB3o8YDfEQsCu50T3uiRDRRpDaZpzIZUN6UozohKlNxaNemIjRZZWyizKmTR9lYnGNL8RhT4RzFXI1iLg7Oxorf5XrYvDXWIGxMpF8I4n0LyWsq9ZBKFFKpBxytFjhSLnF0rsDRY0VsJiR4IiB/JKDwRED+aIHi4RL5IxGFQxWCY2V0bA4dm/Egd12ZQc2HEbphksuHi0skjd72RJFoIk91MqS8KaA8NR/a1ak6bKhRnCyzZXyOrePH2FKcYTKcYyqcY2M42/yMvCKqSf2k3GbR2EZ4b8jHr50K55jOH6GkKifnDwNQUoU5KzBXz3MoGmd/bZJ9lUnuP7aVh49O8fihDUSHCuQPBhQO5SgdzFM6UKJ4cIL8ofG4V/7EkbhmPjvrQe5Gggf4OtXocWtsLC6TFAsQBs3grk0WqE6FVCZzbYM7KEYUSxU2T8wyPXaMDfky04WjTIVzTAZzABRz8UiRcj1PXhHk5nvfR2qlZs+6kIuS/ePe+nT+CCeHh+NbcJS8jJLi8sqcGVUTcxYwZyGHNo1xf+UE9lS28P0jJ/OTJzbz2OOTzBwoUHw8oLQ/YPyxPKX9VfKHiuQOz5ALg7hHTvwl40HuYqIWeQ/cZVyj193scU+MN09IRhN5KpvyzKXKJLVxqG1YWNsGqFZDDh4boxoF5IOIR8JJCkEcxo1QbkzPWYkConqOmWqBuWrI7FyBepSjHolcYOSCOmOlCpOlMtNjx3jS2GG2lw4yHR7h5PxhNuVm2JSbpZSc8dwWGiXVmbMnOKf4BIfrP+SxqRLfP+FJ7D71JHYdfDI/ObCZQ49sYPaxgLFHi0w8ElJ6vET+QAkdPorCkPrsLDk8xN365AG+jiwI7qTXbRsnF5RKamM5yhtzVDdAdQLqheSWNyww1PKe1WrI43MF6pEWnniMBMktHlmieGRJJT4Jma9AUIlHnTRGqpTHJjg2buydqHPHZJXJqVlO2HCUJ284yNPHH+PpxUf5qcIjTOZqlBR/MWzMlZKWzFG1MieHhzh5wyG2FQ5w78YTuXPLKdy3fyuHtkwwNx0w/mjAxCN5io+XyD96hNyxAnZsxuvjbl3yAF8n2va6J0rUNpaobshTG89RmcwRleLhf43wNsVD+sJjOWyuZTx3JHIVCA1yleTWZiggJPerRlCpE5Qt3i8Z722hsEBEBVEdF1EpoDoRUNlQ4v7JTdw7cQo3tAT6tlIc0o3eeUnxFZ8nB0coKWJTbpbTCo/xtNI+7pk8hR9On8gPHzqJQ5tKlKcCNjw8xvhYSGF/kdzhIjp8xHvjI84ML6G4bEmPLsmNjcW17olx6huKC4YDVsfjsduNK4nj3nI8dtsMVJ7vRYdz8XNBJQ7l/Ew8PjtXri+6CKdBNYvHbNfqUKvPX2WZsDCAMNe8EKieD6hNBFQmc9TGclQnSlQnSjwwuZl7p05Fmyps3nyM7VOHOG3icU4tHuIphf1sCo5RUi2uj0cTzFmeEwtHKG6ssaU4w/emTuLxqSmqk3mqEwXGJgPGH8oTFAvkDh9p9sbrs3PH65/IrUOSfo94hkED7gTekmz/LvA04ITWucBTr30T8F+Tzf9uZp/ttx0e4ENsUa+7WIBikWjjeLNkEhVEVFQc1El45ypQSMK70Ytu9KDzM0Y4W29eTJMrx1dH5srVhcEcpQK6cXl8S2inKbnsPghDgiDAwoB8KaQUBAsCvTaWS8ael5idKnH35FZu3/wUgskqWzcd5SlTBzl9Yj/T+aPNk6jbCgfYEIwDUDihxo+Lczw4voVDG0pUJwKi4hjjj4QUwhwKA3Rsttlu742PjkHNRijpVOB3gDPNbFbSNcBFwLeBrxKvstPptVuA9wPnEIf/dyTtNLOD/bTFA3xItQvv9NDA2ljQvKQ9KBv1QASRkUv1wLtd/UjL5ezpgLY2E0+lqXV+lDLxBUPlSvx8EKDD8WMBQBhSTF2u3ziG6mRAeWNIZSoekbJv81a+u3V7M8xPGTvEVDjHE7US5XpIMVfj9KnHCXJ19hQ2caQ0Tm0soDZWYKKYo1jMExwIySXHkGPWQ9z1IwTGJFWBceAhM7sVQGo9k7TAq4HrzexAsu/1wHnA5/ttRFeSzgM+BgTAVWb2oTb7vB74APG3yu1m9oZ+GuS6a4R3bmwsDsWWUSaWWzg/iSKjcKQxD0m8HZTrBLM1cnPRfGCXy3FIJyHbOrEU0HbGQKC3Ca1qtflgb3wZlBuvj79Z9AQEQUAQBhTCsHlcjWGPc5tylDePcWjLGPumtzB+8lFOnDzKqRsOMxnOl0W2FGeZm8yzH5gplKgX8tTz8bmA8TBHGATxuHHwEHftTEvaldreYWY7IF7TUtL/BB4AZoFvmNk3enzfU4EHU9t7ksf60vV/naQAuBJ4ZfJhtyRd/ntS+5wBvAd4oZkdlHRivw1yS1sQ3sXCojlLGuEdTxBlzflCcpGRq9RRVO8Y2o05RoBlTe2ay4fz+ycBnQ799JSzHXvubR5XGKIwIDgcEJSKFIoFShvHqE3mKW8KmTkhoLx3Iz85cZKfbNnK5s3H2Dw2QyGIqEQBpbDKts2HeDg3xUwwRlQsUBuLSyoTxYB8KY8ejy8k8lEqI8Dmp3XoQcdV6ZN1LS8kXsT4EPC3kt5oZv9nMA3tXS898HOB3ckKykj6AnHj0+u4/QZwZaOOY2b7Bt1Q16bnnYS3lUIsnP/BbAR342RjrtwI7BoqV+KwTOYRgZXP8Fev1uZPptZqi3rji+b97lG7L4HwQJGwWKA4Mc7ExjHK00VmtwbMnFji8IlFDpywgS3TRxnLV8nn5ks++fEqlWkxQ554ktoC4zlRgGZd3EepuB69AvixmT0GIOnvgZ8DegnwvcBLU9vbWKJm3k0vAd6uy//8ln2eASDp28Rllg+Y2ddb30jSZcBlACXG+2nvyFoU3sVCMid3DguS8kPNyJGEVpX2Pe2kll2fnT+RBwMOrTYhvqzXttGYmNaqVTSXR+UK4bEZgsPjFA6NM/Z4gZnHA2b3FTl8YoED01Xy48mc4kGdfL5GrRhQ2yxmCLFcDgsKWCiKxBNx5cBDfB2z5fXAl/IA8AJJ48QllJcDu5Z+SdN1wB8nvXiAVxFXL/oyqJOYIXAG8TfLNuBGSc9uXak5qSHtAJjSFmt9E9de+oRlM7yLxXhoHsRzZydUY8G82qRm7Wstj6xqSPUS4l1OhHbat1nqOQK5Y7PkDx8h3DhJcf8Y49PFOMi3Fph9Up5oqkauGJELjHo5QEA0Vqe8KYfqQlGIahNxTxwPcdedmd0s6UvAd4EacCuwQ9LvAO8CTgbukHStmV2aXpXezA5I+iBwS/J2VzROaPajlwDfC2xPbW9LHkvbA9xsZlXgx5J+SBzot+BWZNHVlUEwH4xJ2US1+vyfjaF+SXA3e9urHNoLyigNrSG+nMDupnE8s7OoVkt65GPzPfKtRWYOBsyclKeyKSSaqKMgvtqUXHwRU3UC5jbnyNXyqD5OHg9x1xszez/xcMC0jye31n2bq9In21cDVw+iHb0E+C3AGZJOJw7ui4DWESZfAS4G/rekaeKSyn2DaOAoa3dpfHMZM4Ba+kKaVHC3npRcy5NzKwjtbm1unDy1Wg0Lw2aQ58sVgmPj5J8Yo3g4z7GTc5Q3B9TGwQIjV4lH6FgQh3i5kiOo5FFUIkz+HlWrYeAhvq5owZz060HXADezmqS3EdduAuBqM7tb0hXALjPbmTz3Kkn3ABHwB2b2+Go2fOSkgzux4KKaxnjtrAT3CvTa5sZ+C4K8WkVzZXJzZYpHywSzGygeyjNzUp7Z6Xhxiqi4cPWgqACVyRzhTEhuokhQrjTLUt3Guzu3lnqqgZvZtcC1LY+9L3XfgHckNzcA7Usn6dRpLAS8cN3ItVozclH5pE/9joJptiHpOduhw+SiiLBcJrd1ilylRDiTZ25LQHVDPMGW6qn3CKAyGZCr5MmVS3FvvhZhYei98PXCkpWg1hG/EjOD0mHYXPIsLX3peptRJZkImz5q3yttdzPIG9tHjpKrjZGrReTnJsmVxygcyTM7HVKdyBEV4p54LplOwALFCzUX8wTFIpQrKJ+Pr9jMh9n4e3UuxQM8qxqjTtLSc40kwZ0ul0BGeoqto0/CsGuID7LdzROqtdr8SU4grEWoNo5q1lzMIirEk3Y1XxuIeikgV86jcqHZCx/oCVjnBsQDPGMWlU4aGiWTIGgb3msZ3AvKJ52GDi4RgqvR9nSIG8CxGRRFBFGEonFy1QK5cp7qZEBjFThF8cjWej5Y3AsHyMKXo1sZ8xKKW0stJykhI71uWBDeyuf7vgJzUFpD3KpVckCuVkO1DfGFT1Ge2nhAPZif2xzAwhwWBqiY9MKrVS+juMzxAM+Q9ALEC7TMApil8G5dNDktKyEOSV08DLG5MgJ0+ChBc/y8LZj8qynMxccWBl4LXw/8JKY7HhbVvhNZC++0RSUf4vYuCPE2ZZTjegyNcgrxBTsiHherWvtZHC3MoSCAIEBh6LVwlzke4Bmx1DC8BdO6Zii827Y5NWIm3dfJQk98QU2c+RBvjlopBVg911xpyJKFJxQGEC0eh+/cWvMAz5I2Pdjm/YyFN3S4fD4tDJZcped46xjiyVhvRSH1Yvzbj1JXuRKGfjJznZCXUNygdbsIJovhvRyN0opVqz0NKVxNrSGuMISkLg5xb7wxuyMQ18FrqTKKn8x0GeIBnkGLyg1ZD+90GNaihRceZawXDovHiTdKKM2+WSm1c6MnHgZQpnky0w0hE3gP3B1XGQ/vdBnF0kumtdFuVEoWerOWXOhDGMQnLedozvS4QBg0Z1j0y+tHm6RNwFXAWcTT1f868Yr0z0x22QQcMrOz27z2fuAI8bxRtU4r//TCAzzLMh7ey6EwzFTPtW09vLHgMkUWTVaf/HbRKKO4kfcx4Otm9jpJBWDczH6l8aSkjwCHl3j9y8xs/0ob4QG+xjrWvzMUdivWWkbJyHC8tvXwIALKxOv0tJEaE+6GjDGQEoqkjcCLgTcDmFkFqKSeF/B64BdW/GFdDGR9ITcgtdr8LTEMve96NW6zVatxsGWs5t0rS9YKbU4SFrUcx4LafjiwGRjd0DkdeIx4/YNbJV0laSL1/IuAR83sRx1eb8A3JH0nWWaybx7gGTYM4b0cajdB1xpr/h2nv4Aa86vDfJCnvlSXqvO7bFO9txswLWlX6pYO2hB4LvAJM3sOcAx4d+r5i4HPL9GMnzez5wKvAd4q6cX9Ho//JGbUugnvxuRbGS2jtFWLaP5G3KGdfmn9urd/iZOLe4A9ZnZzsv0lkgCXFAK/BDyv0xub2d7kz32SvgycC9zYTyO9B+4GpzXoGuOpg6WvYlzrUkTbXngtSm5LhLP3xEeSmT0CPCipMeLk5cA9yf1XAN83sz3tXitpQtJk4z7xqvR39dsW/wnMoGHs0TVOCFq12r7EkIR44xTSUIzkaK2Bu+FmA70S87eBzyUjUO4D3pI8fhEt5RNJpwBXmdn5wEnAl+PznITA35jZ1/tthAf4Gmu9HH0Yw7tVc1x1a887yG4ZpdNl9sDi42iMB094GWX0mNltwKISi5m9uc1jDwHnJ/fvA35mUO3wAM+QYQ+BerUW1+RaT1Q2Rm8kV2m264VnLQQbbYsnsooWhXhzPHiGvoRcd1pnv1R5DTwD6tWMrGM5IM1gbjcMr3Vx5izWkdOB3PiNoc2wwqyNqHGjxwPcrYpFF7o0gjqcnxgqawHY+iU67OPa3frnAe4GrxHenYIvjHvhrSc713o0ygJLlUXaHFem2u7aUnISs5fbsPCfOjdQi0ajRKnZCdOBnYRgc47tjNSRW08qN2vha9Ug55bgAe5WTTw7YTLypLXWnYR6c65wgKxdGJPMPNiVn8gcGn4S07ku0nOjNMsN7WriYcsJzYxY8AWSvrinjazV8d1o8QB3q6o5twi076UGASoV4yBMertZqCe3+y2gNcQzXcN3i1ncA+/lNiw8wN2qWNQLX+qEJhmfIKpxHM5lTIb/17j1onllJoX2OzQus0+d0MxCLXzBCc30FZotXzZZOxHrRocHuFs1jSsz54OvMRqlfd070yc0E/NXaLb/r5PFNrt5WrTU0nDzAHeralGIlzqsdAPNy+yzVK5o7YU36vRt1//00SjuOPMAd8dHawmicVl9G1krpSzQWH6tZVm19ILNmWuzi9lwnaDshZ/EdKuu43zbUdR+6TLI1KiURWG81EnNLJ+MdeuOB7g7LpZeNCHqPFIl4yHeCPLWQF/r9rrVJel+SXdKuk3Srpbn3inJJE13eO2bJP0oub1pJe3wnzJ33DRCMEdcQ7bUhFbtTgqmyxKZlNTEM91G1yQGXkJ5mZntX/AZ0nbiVXYeaNsGaQvwfuK5xA34jqSdZnawnwb01AOXdJ6kH0jaLendS+z3y8k3T6e15Jxb1BuHJNCT2yJZ7YVDHOK1hVduNqxme3P5cNHNZcJHgXcxf96+1auB683sQBLa1wPn9fthXQNcUgBcSbyC8pnAxZLObLPfJPB24ObW55xrtSDEZ2cXlCPaykiId9Qa5Ax+gQ4P6xVa3pWYS61Kn7wb35D0ncZzki4E9prZ7Uu04lTgwdT2nuSxvvTyk3AusDtZCghJXwAuZH4Rz4YPAh8G/qDfxrjR0iypJEuZdS1HJMP0GgGW5ZEeg2ybB/aaWGpVeoCfN7O9kk4Erpf0feCPiMsnx00vJZSu3xiSngtsN7N/XOqNJF3W+EarUl52Y936lO6NL2cc9fEOtm6f11hZaRDhvdzedpa/zNYjM9ub/LkP+DLwEuB04HZJ9wPbgO9KOrnlpXuB7antbcljfVnx/wBJOeDPgDd329fMdgA7AKa0ZZ1dE+VWYlFvvKHLsLzj0RvvJURX+vmLPmOp417lUs26NaBx4JImgJyZHUnuvwq4wsxOTO1zP3BO60lO4DrgjyVtTrZfBbyn37b0EuDdvjEmgbOAGyQBnAzslHSBmS0YXuNcNwuCHHruka9GkC+nh7/ci3favnebOVYgW1emOgBOAr6c5F0I/I2Zfb3TzsmgjsvN7FIzOyDpg8AtydNXmNmBfhvSy0/oLcAZkk4nDu6LgDc0njSzw0BzvKOkG4Df9/B2K7EoyHuU3r+fMF9JWabdZy8nqPvhve/lyQ2gB56cD/yZLvuclrq/C7g0tX01cPXKW9JDgJtZTdLbiLv+AXC1md0t6Qpgl5ntHERDnGundYmz5ViVGnmPV1rmegjpblPoNoZULhgPn/qNxMPb9fTTaGbXAte2PPa+Dvu+dOXNcm5ev73xgegQsp16zR1DuXUGxnbzwDQXvljYTfTwdp34+CQ3NFYc5Mucp6Q1pJvhnA7jYOkpcnvSCOwgWDQvTGt4e3D3Twaqr3UrBssD3A2dnoN8icBequ68eJrYJJyD1BqeYQhBgDW3exiRW4vTQ43AjqKFJ2mj+flgLD1hloe368AD3A2tQZZWFvWuW3vWSSHNCKMAAAwUSURBVGADcWgngW1hDms+vjDE1QjsKIrvhzmo1bEwmA/xhnbh7cE9cOttOlkPcDf0OgZ5o3fbpXSyILzTwd14vNHTToU2gAXB/P1QWNAS4KFQbf5yB6V74I3ed/N+tCi408fmXDse4G7dSIfdgjBvE+RWrbYvo0RRx4Um0hq9btXqzRBXtLDAuii8a/X58J4rLw7uVFs9uF0vPMDdutQ2zFuCvBHizeF6EPe80ycSW3rvrWUSiMNZtfi5Ri8bUqWTWh2VK97jXmvrcEUeD3C37i0K81RgLprPoXWty1oUr9UZhVCbP4mpsM1whjILT1S2KZOA17jd4HiAu5HSS5g3eubNII8CKFcgCOZ76Z00wjq53+jd+1jubBjElZhZ4gHuRlZrgKaLI8bCOUjS9fJOF+ukF6NoF9jtPtO5lfAAdy6xIFxbRrbYUmWXbu/l3CrxAHduCR7E64fW4UlMX5XeOef6ICmQdKukrybbp0u6OVk7+IuSCm1ec5qk2WQ1+9skfXIlbfAAd86NDNWtp1uP3g58L7X9YeCjZvZ04CBwSYfX3WtmZye3y/s/Gg9w55xbNknbgP8IXJVsC/gF4EvJLp8FXrva7fAAd865xbqtSv/nwLuAxgUBW4FDZtY4abLUavOnJ6WXf5H0opU00k9iOudGw/JOYnZclV7SLwL7zOw7kl66zFY8DDzZzB6X9DzgK5L+g5k9scz3ATzAnXNuuV4IXCDpfKAETAEfAzZJCpNeeNvV5s2sTHzNLskXwL3AM4C+lqD0EopzbjRYfCVmL7cl38bsPWa2LVn38iLgn83sPwPfAl6X7PYm4B9aXyvpBElBcv+pwBnAff0ekge4c84Nxh8C75C0m7gm/mkASRckawgDvBi4Q9JtxCc8L1/tVemdc861YWY3ADck9+8Dzm2zz05gZ3L/74C/G9Tne4A750aCAEU9j/EeCl5Ccc65IeU9cOfcaDDIrbOpbbwH7pxzQ8p74M650WBeA3fOOZcRHuDOOTekvITinBsJYv2tiek9cOecG1LeA3fOjQYzP4npnHMuGzzAnXNuSHkJxTk3GgxU8xKKc86NLEnbJX1L0j2S7pb09uTxL6ZWm78/mTK23evPk/SDZPX6d6+kLT31wCWdR7ziRABcZWYfann+HcClQA14DPh1M/vJShrmnHODlhvMScwa8E4z+66kSeA7kq43s19p7CDpI8Dh1hcmizlcCbySeN3MWyTtNLN7+mlI1x546gNfA5wJXCzpzJbdbgXOMbOfJp6k/E/6aYxzzmWdmT1sZt9N7h8BvkdqAeNkhfrXA59v8/Jzgd1mdp+ZVYAvABf225ZeSihdP9DMvmVmM8nmTcTrwTnn3LDqtio9AJJOA54D3Jx6+EXAo2b2ozYvORV4MLW91Or1XfVSQmn3gc9fYv9LgK+1eyL5S7gMoMR4j010zrmV0/JOYnZclb75ftIG4tV1frdlVfmLad/7HriBjkKR9EbgHOAl7Z43sx3ADoApbVlfp4OdcyNDUp44vD9nZn+fejwEfgl4XoeX7gW2p7bbrl7fq14CvKcPlPQK4L3AS8ys3G+DnHNuVRiovvJ+Y1Lj/jTwPTP7s5anXwF838z2dHj5LcAZkk4nztGLgDf025ZeauDND5RUSD5wZ3oHSc8BPgVcYGb7+m2Mc84NgRcCvwr8QmrY4PnJcxfRUj6RdIqkawHMrAa8DbiO+OTnNWZ2d78N6doDN7OapMYHBsDVZna3pCuAXcmKy38KbAD+Nv5y4gEzu6DfRjnnXFaZ2b8ST27Y7rk3t3nsIeD81Pa1wLWDaEtPNfB2H2hm70vdf8UgGuOcc6vHUFRf60YMlF+J6ZxzQ8rnQnHOjQafC8U551xWeIA759yQ8hKKc240GKjmJzGdc85lgPfAnXMjQRiK1tey9N4Dd865IeUB7pxzQ8pLKM650eAnMZ1zzmWF98Cdc6PBDLwH7pxzo03S1ZL2Sbor9dgHJd2RTC/7DUmndHhtlJqGdme7fXrlAe6cc8v3GeC8lsf+1Mx+2szOBr4KvG/Rq2KzZnZ2clvRtNteQnHOjQYD1QYzDtzMbkwWNE4/ll4XcyL+xNXlAe6ccwMi6X8AvwYcBl7WYbeSpF1ADfiQmX2l38/zEopzbkQYRFFvN5iWtCt1u6ynTzB7r5ltBz5HvHRaO09JVrx/A/Dnkp7W7xF5D9w55xbbn4Rsvz5HvIrZ+1ufMLO9yZ/3SboBeA5wbz8f4j1w55wbAElnpDYvBL7fZp/NkorJ/WniBZLv6fczvQfunBsNZlCrDeStJH0eeClxqWUPcU/7fEnPBOrAT4DLk33PAS43s0uBZwGfklQn7kB/yMw8wJ1z7ngxs4vbPPzpDvvuAi5N7v8b8OxBtcMD3Dk3GgwY0DDCrPAauHPODSnvgTvnRoNZY4jguuE9cOecG1Ie4M45N6S8hOKcGxHmJzGdc85lg/fAnXOjwcAGdCFPVngP3DnnhpQHuHPODSkvoTjnRoMZVq2udSsGynvgzjk3pLwH7pwbDQOcjTArvAfunHNDqqcAl3SepB9I2i3p3W2eL0r6YvL8za2LfTrn3HqSlUzsGuCSAuBK4DXAmcDFks5s2e0S4KCZPR34KPDhQTfUOedWwsyoV2s93ZaSpUzspQd+LrDbzO4zswrwBeLlgtIuBD6b3P8S8HJJGlwznXMuMzKTib2cxDwVeDC1vQd4fqd9zKwm6TCwFdif3ilZ2bmxunP5m/Vr7uqn0Rk3TctxrwPr8ZhgfR7XejwmgGeu9A2OcPC6b9avme5x95KkXantHWa2I7k/sExcqeM6CiX5C9gBIGnXCld9zqT1eFzr8ZhgfR7XejwmiI9rpe9hZucNoi1Z0ksJZS+wPbW9LXms7T6SQmAj8PggGuiccxmTmUzsJcBvAc6QdLqkAnARsLNln53Am5L7rwP+2cxscM10zrnMyEwmdi2hJPWbtwHXAQFwtZndLekKYJeZ7SRejfmvJe0GDhAfUDc7uu8ylNbjca3HY4L1eVzr8ZggQ8e1ipm4bPKOsnPODSe/EtM554aUB7hzzg2pVQ/wrFxyOkg9HNM7JN0j6Q5J/yTpKWvRzuXqdlyp/X5ZkknK/HC1Xo5J0uuTf6+7Jf3N8W5jP3r4GXyypG9JujX5OTx/Ldq5HJKulrRPUtvrQxT7eHLMd0h67vFuY+aY2ardiAv89wJPBQrA7cCZLfv8FvDJ5P5FwBdXs03H6ZheBown938z68fU63El+00CNwI3AeesdbsH8G91BnArsDnZPnGt2z2g49oB/GZy/0zg/rVudw/H9WLgucBdHZ4/H/gaIOAFwM1r3ea1vq12Dzwzl5wOUNdjMrNvmdlMsnkT8TjRrOvl3wrgg8TzOswdz8b1qZdj+g3gSjM7CGBm+45zG/vRy3EZMJXc3wg8dBzb1xczu5F4xEYnFwJ/ZbGbgE2SnnR8WpdNqx3g7S45PbXTPmZWAxqXnGZVL8eUdglxryHruh5X8ivrdjP7x+PZsBXo5d/qGcAzJH1b0k2ShuFqvV6O6wPAGyXtAa4Ffvv4NG1VLff/3rrnCzqsIklvBM4BXrLWbVkpSTngz4A3r3FTBi0kLqO8lPg3pRslPdvMDq1pq1buYuAzZvYRST9LPCb5LDOrr3XD3OCsdg88M5ecDlAvx4SkVwDvBS4ws/JxattKdDuuSeAs4AZJ9xPXIHdm/ERmL/9We4CdZlY1sx8DPyQO9Czr5bguAa4BMLN/B0rEE10Ns57+742S1Q7wzFxyOkBdj0nSc4BPEYf3MNRUoctxmdlhM5s2s9PM7DTi2v4FZrbiSYZWUS8/f18h7n0jaZq4pHLf8WxkH3o5rgeAlwNIehZxgD92XFs5eDuBX0tGo7wAOGxmD691o9bUap8lJT5z/EPis+bvTR67gvg/P8Q/WH8L7Ab+H/DUtT6zO4Bj+ibwKHBbctu51m0exHG17HsDGR+F0uO/lYhLQ/cAdwIXrXWbB3RcZwLfJh6hchvwqrVucw/H9HngYaBK/JvRJcDlwOWpf6srk2O+cxh+/lb75pfSO+fckPIrMZ1zbkh5gDvn3JDyAHfOuSHlAe6cc0PKA9w554aUB7hzzg0pD3DnnBtS/x+2F60PRleZEAAAAABJRU5ErkJggg==\n",
+            "text/plain": [
+              "<Figure size 432x288 with 2 Axes>"
+            ]
+          },
+          "metadata": {
+            "needs_background": "light"
+          }
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 57,
+      "id": "YDTVYHhmz4Y-",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 269
+        },
+        "id": "YDTVYHhmz4Y-",
+        "outputId": "e40d5d4d-f87d-4159-c226-7bb22d288067"
+      },
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAQYAAAD8CAYAAACVSwr3AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAATcElEQVR4nO3db4wdV3nH8e8PO3EIiU1tF+PYTuwEJ8KFCoyVAKkaqoTKSYX9AoTsitK0aVwoiYpAqKlAFIX2RVpBK5Bb6tI0gATB+EW1CEdp4wZFCjHEkBCwI9ONMbGd1GlMiEr+ODY8fTFzdmfn3PUd27N37jW/j7TaO3PP3vvs3dUzz5w5c44iAjOzqpd1HYCZDR8nBjPLODGYWcaJwcwyTgxmlnFiMLNM38Qg6XZJT0n64TTPS9JnJI1LekTS6vbDNLNBalIx3AGsPcHz1wIry69NwD+dflhm1qW+iSEi7gN+eoIm64EvRmEn8EpJi9sK0MwGb3YLr7EEOFDZPljue7LeUNImiqqCWcx607nMbeHtzWw6/8czT0fEr5/sz7WRGBqLiC3AFoC5mh9X6OpBvr3Zr5x7YttPTuXn2rgqcQhYVtleWu4zsxHVRmIYA95bXp14M/BsRGSnEWY2OvqeSkj6CvA2YKGkg8BfAWcBRMTngO3AdcA48DzwRzMVrJkNRt/EEBEb+zwfwAdai8jMOueRj2aWcWIws4wTg5llnBjMLOPEYGYZJwYzyzgxmFnGicHMMk4MZpZxYjCzjBODmWWcGMws48RgZhknBjPLODGYWcaJwcwyTgxmlnFiMLOME4OZZZwYzCzjxGBmGScGM8s4MZhZxonBzDJODGaWcWIws4wTg5llnBjMLOPEYGYZJwYzyzgxmFnGicHMMk4MZpZxYjCzjBODmWUaJQZJayXtlTQu6ZYez18o6V5JD0l6RNJ17YdqZoPSNzFImgVsBq4FVgEbJa2qNfsYsDUi3ghsAP6x7UDNbHCaVAyXA+MRsS8iXgLuBNbX2gQwt3w8D3iivRDNbNBmN2izBDhQ2T4IXFFr8wngPyTdDLwCuKbXC0naBGwCOIdzTzZWMxuQtjofNwJ3RMRS4DrgS5Ky146ILRGxJiLWnMWclt7azNrWJDEcApZVtpeW+6puALYCRMQDwDnAwjYCNLPBa5IYHgRWSloh6WyKzsWxWpvHgasBJL2WIjH8b5uBmtng9E0MEXEcuAm4G3iU4urDbkm3SlpXNvswcKOk7wNfAa6PiJipoM1sZjXpfCQitgPba/s+Xnm8B7iy3dDMrCse+WhmGScGM8s4MZhZxonBzDJODGaWcWIws4wTg5llnBjMLOPEYGYZJwYzyzgxmFnGicHMMk4MZpZxYjCzjBODmWWcGMws48RgZhknBjPLODGYWcaJwcwyTgw2xexLVjD7khVdh2Edc2Iws4wTg5llGq0rYaNpulOCo8vnAzBrx3cn9j373rcAsOD+/+n5Gscf+/FMhGhDyhWDmWVcMZwhfnH1myYeH14zdSXxC7c9CcCRK189Zf+8yuPzDr00tU2t7YLye6o2YLLicFVx5nHFYGYZVwwjIlUE6Sid+gSeWyxgsioAWMT8KT/7+LsWA/CKJ4t1hlM/wvFKmzn7fwrA4TVF20W7jk55jXq1AXBeqlJcOZxxXDGYWcYVw5B74i/eOmX7FUumXj04rzznrx7Rj1z7AgAXfX4WMFlNpP6BdESv9kv8ovxeb/vzJWdPeb9qH8NbPvUdAP7z0781JcYF5FxFjBZXDGaWccUwRNI5eq/z+brqkbvu4o0PT9lOfQmzakft6jiGett0XWPOfqbElK5eADzw4cuLB0t6x+EqYXS5YjCzjCuGDtV78VMVUD0qP7e4OHZfcNu3gMl+gXQVIf3sgsoox+rVhlNVP9rP63H0T/HP2V9sp6sf8/7lWBHr30z2YdSrE1/BGG6NKgZJayXtlTQu6ZZp2rxb0h5JuyV9ud0wzWyQ+lYMkmYBm4G3AweBByWNRcSeSpuVwF8CV0bEM5JeNVMBm9nMa3IqcTkwHhH7ACTdCawH9lTa3AhsjohnACLiqbYDPRNNXBIsO/bmXX8AgNk3njXR5oIdvTsM66cLXZTk6T3TacHE0OsnlxUNKp2Safh1Gpg1sd+nEkOpyanEEuBAZfsgeT/0pcClku6XtFPS2l4vJGmTpF2Sdh3jaK8mZjYE2up8nA2sBN4GLAXuk/T6iPhZtVFEbAG2AMzV/GjpvUdOvQNxzv5i/+OLLwTggse+NfCY2pAqiHm1SgLgSO227tRRuaB2a7g7I4dDk4rhELCssr203Fd1EBiLiGMR8WPgRxSJwsxGUJOK4UFgpaQVFAlhA/D7tTb/DmwE/k3SQopTi31tBjqqek2WMrusFOqDhiZuhKpeehyBI+h0MVb312/bTjd0UdtfvWF8FH73M1XfiiEijgM3AXcDjwJbI2K3pFslrSub3Q0ckbQHuBf4SEQcmamgzWxmNepjiIjtwPbavo9XHgfwofLLKnrdsJT6FuZ98QEgryrOxCNl+p0mK4KpQ7rTzVpz9g8oIDshD4k2s4yHRHcg9S3Ur+EPulKY3UFfRnqfdEPX3n94MwALvzeQt7eGXDGYWcaJwcwyPpVoSf1uwbRdn28R8jkXB30K8YvaXI1VM33XY3r9dHnykg/unBrTiOs1p0bqZB4lrhjMLOOKoSX1I2w6YqTZlqvzERxNMz53fFmy1yXUmVbvfExH2DTn5JTZq1In7QgdcZvMvjUKXDGYWcYVQ0umOzefmGW5OohpSNZh6FUldB3L/ncsmtinRS8CsOD+0Zvt6enV1T6l0YvfFYOZZVwxtCxVAWmFqNTH0Oto0fURpPr+aQKVQU+cUv8MLvvs5OO9NxfVw5ErXw5M3ojV9efWS31lsFEfsOWKwcwyrhhaUr9Z6oXFvwR6r93QlVTN7PuT4hrAOWvemrVZMESzNy/8XnH0nbgq0eMW9q6lz7S+Mlj1797GrN2D5orBzDKuGE5TfaRbOnIs//r8Kc93eQSu39ad1rT8+ZLhmV2v14Q26Xz9uXL9zokVuHsclbtSXxGs11WoYai+TpYrBjPLODGYWcanEi2ZuDGqLBvTWhGzdnRfRmaDrsrYUqkOlfkmO9Kr3L5wW/G9Xq5PLM8300E1kE5n0uXKI9e+UD4zOTS6V4fksHPFYGYZVwynqX6ZMs1pOMw3/qTqhsoNP/XO065UOyEnVuoqO/Sqi/0OixRv+nufd6i8QW7H8P79m3DFYGYZVwynqX7b8I/+ulil8aLPpyPH8J1X1leMgsmKJx2lu74lHCb7En6+5NXl96JyGIZ+m/pEPC++If3dOwupVa4YzCzjiuE0paPv4bQW413FoKE5+6dO3zaMqufzaXWsVPFcvKOTkKZcnUhVTOrpX3DXyzuJqao+YG3RrqLC+skbiudn1W6pr7YdJa4YzCzjiqElF9xWrFA9DEOgT0W6KnHOw8XYhnS0HoY+klQppKsSXX7G6T2fKIdpT07yW1Q1z9ZW9R5VrhjMLOOKoSW9bgIadtURhek6fLphKUlHxlQRDVKqVs6rTS3fZTWWKql0Q9f+d5wFwGUfe7ZsUXwftYqxzhWDmWWcGMws41OJltRXoBoF1Y7FFHcqkdPgohfKWZt7daoNqlwedAdovXOz1ypZ6fO55INFm2G+LH0qXDGYWcYVQ8tGtdOpvkJUWi0rzbuYLhVWOyyHYdj0TBjVv2GbXDGYWcYVg/WUzqHTDUupj6HquQ4vZbZpugFTaf8Ta+ZkP7OI4bnZbCY0qhgkrZW0V9K4pFtO0O6dkkLSmvZCNLNB61sxSJoFbAbeDhwEHpQ0FhF7au3OB/4c+PZMBGqDVe+RT1cjqn0MT68+a/CBzYD675qugqRh4tVp77KrTyM6BL6fJhXD5cB4ROyLiJeAO4H1Pdp9ErgNeLHF+MysA036GJYAByrbB4Erqg0krQaWRcQ3JH1kuheStAnYBHAO5558tDZwh8vz6wv3F9vVFbIn1pksj5pHR3DSU5isFNJEMPV1LKrVwKjeJHeyTrvzUdLLgE8D1/drGxFbgC0AczV/eFY7MbMpmiSGQ8CyyvbScl9yPvA64JuSoJg3e0zSuojY1Vag1o10xeFoj9uwZ9cqhXTEJa2cPUQT4tZHpFb7Sn5SruX531d9DoDXbP1T4MxZVepUNOljeBBYKWmFpLOBDcBYejIino2IhRGxPCKWAzsBJwWzEdY3MUTEceAm4G7gUWBrROyWdKukdTMdoJkNniK6OdWfq/lxha7u5L2tHdPdbFTtoEzq61ZMd9PZiTr66jcznaiTM80jkS417r25uBksDfGursJVv3Gs3ok6yvM33hPbvhsRJz2uyEOizSzjIdF2yqYbGPR4ebR+8Q3PT7RNc0k+XR650+3K9XUp02zbkM+jmdbuSO9Tv8wIkzNKX/qxJ6e8/vKvH5vyswt6rHiV1CuFUasS2uCKwcwy7mOwk3Ki8+0TXRJM0tH96dXF/91lnz3c92fq5/7J4R43N72w+JdTttPr1/s0jlTW7Rymy6ptcx+DmbXGfQx2Uk50vl1/Lj+eV9edLAZBpSN3mgjmni/dPtH2mj/4Y2CyUqhXDpNrOkxatOvYlLZJfWq6apXwq9yXMB1XDGaWcR+DDVS/o3OvPowmk7Mmo3YD10xzH4OZtcaJwcwy7ny0gerXwddk7oPUsdjrtdyR2A5XDGaWccVgQ2u6o/7JXDK1U+OKwcwyTgxmlnFiMLOME4OZZZwYzCzjxGBmGScGM8s4MZhZxonBzDJODGaWcWIws4wTg5llnBjMLOPEYGYZJwYzyzgxmFnGicHMMk4MZpZxYjCzjBODmWWcGMws0ygxSForaa+kcUm39Hj+Q5L2SHpE0g5JF7UfqpkNSt/EIGkWsBm4FlgFbJS0qtbsIWBNRPwmsA3427YDNbPBaVIxXA6MR8S+iHgJuBNYX20QEfdGxPPl5k5gabthmtkgNUkMS4ADle2D5b7p3ADc1esJSZsk7ZK06xhHm0dpZgPV6kpUkt4DrAGu6vV8RGwBtgDM1fxo873NrD1NEsMhYFlle2m5bwpJ1wAfBa6KCJcDZiOsyanEg8BKSSsknQ1sAMaqDSS9EfhnYF1EPNV+mGY2SH0TQ0QcB24C7gYeBbZGxG5Jt0paVzb7O+A84GuSHpY0Ns3LmdkIaNTHEBHbge21fR+vPL6m5bjMrEMe+WhmGScGM8s4MZhZxonBzDJODGaWcWIws4wTg5llnBjMLOPEYGYZJwYzyzgxmFnGicHMMk4MZpZxYjCzjBODmWWcGMws48RgZhknBjPLODGYWcaJwcwyTgxmlnFiMLOME4OZZZwYzCzjxGBmGScGM8s4MZhZxonBzDJODGaWcWIws4wTg5llnBjMLOPEYGYZJwYzyzgxmFmmUWKQtFbSXknjkm7p8fwcSV8tn/+2pOVtB2pmg9M3MUiaBWwGrgVWARslrao1uwF4JiJeA/w9cFvbgZrZ4DSpGC4HxiNiX0S8BNwJrK+1WQ98oXy8DbhaktoL08wGaXaDNkuAA5Xtg8AV07WJiOOSngUWAE9XG0naBGwqN4/eE9t+eCpBd2Qhtd9niI1SrDBa8Y5SrACXncoPNUkMrYmILcAWAEm7ImLNIN//dIxSvKMUK4xWvKMUKxTxnsrPNTmVOAQsq2wvLff1bCNpNjAPOHIqAZlZ95okhgeBlZJWSDob2ACM1dqMAX9YPn4X8F8REe2FaWaD1PdUouwzuAm4G5gF3B4RuyXdCuyKiDHgX4EvSRoHfkqRPPrZchpxd2GU4h2lWGG04h2lWOEU45UP7GZW55GPZpZxYjCzzIwnhlEaTt0g1g9J2iPpEUk7JF3URZyVeE4Yb6XdOyWFpM4uszWJVdK7y893t6QvDzrGWiz9/hculHSvpIfK/4fruoizjOV2SU9J6jkuSIXPlL/LI5JW933RiJixL4rOyseAi4Gzge8Dq2pt/gz4XPl4A/DVmYzpNGP9HeDc8vH7u4q1abxlu/OB+4CdwJphjRVYCTwE/Fq5/aph/mwpOvXeXz5eBezvMN7fBlYDP5zm+euAuwABbwa+3e81Z7piGKXh1H1jjYh7I+L5cnMnxZiOrjT5bAE+SXHvyouDDK6mSaw3Apsj4hmAiHhqwDFWNYk3gLnl43nAEwOMb2ogEfdRXA2cznrgi1HYCbxS0uITveZMJ4Zew6mXTNcmIo4DaTj1oDWJteoGiizclb7xliXjsoj4xiAD66HJZ3spcKmk+yXtlLR2YNHlmsT7CeA9kg4C24GbBxPaKTnZ/+3BDok+U0h6D7AGuKrrWKYj6WXAp4HrOw6lqdkUpxNvo6jE7pP0+oj4WadRTW8jcEdEfErSWyjG8bwuIn7ZdWBtmOmKYZSGUzeJFUnXAB8F1kXE0QHF1ku/eM8HXgd8U9J+inPLsY46IJt8tgeBsYg4FhE/Bn5EkSi60CTeG4CtABHxAHAOxQ1Ww6jR//YUM9wpMhvYB6xgshPnN2ptPsDUzsetHXXgNIn1jRSdUiu7iPFk4621/ybddT42+WzXAl8oHy+kKH0XDHG8dwHXl49fS9HHoA7/H5Yzfefj7zG18/E7fV9vAAFfR5H9HwM+Wu67leKIC0Wm/RowDnwHuLjDD7dfrPcAh4GHy6+xrmJtEm+tbWeJoeFnK4pTnz3AD4ANw/zZUlyJuL9MGg8Dv9thrF8BngSOUVReNwDvA95X+Ww3l7/LD5r8H3hItJllPPLRzDJODGaWcWIws4wTg5llnBjMLOPEYGYZJwYzy/w/qM19/36Y7cYAAAAASUVORK5CYII=\n",
+            "text/plain": [
+              "<Figure size 432x288 with 1 Axes>"
+            ]
+          },
+          "metadata": {
+            "needs_background": "light"
+          }
+        }
+      ],
+      "source": [
+        "hist2d(batch[:,0], batch[:,1],100, range=[[0,1],[0,1]]);gca().set_aspect('equal');"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 58,
+      "id": "427774db",
+      "metadata": {
+        "id": "427774db"
+      },
+      "outputs": [],
+      "source": [
+        "x = model_inv.apply(params, batch)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 59,
+      "id": "acdc9ad7",
+      "metadata": {
+        "id": "acdc9ad7",
+        "outputId": "88a4c5d4-1837-4108-90ca-c563d7d4cb99",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 269
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAQYAAAD8CAYAAACVSwr3AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAVRUlEQVR4nO3df+xddX3H8eeL1oJslKrMzbQVqivGTpeADehMJhuyFIz0DxfTKtm6EBudGDMXExYXZ+pfzkwzk26uyRzqVKz8sdSIYUMxJI5qIVW0JXWlylokMhVwiRNoeO+Pe8+393s+59zzOfee++v7fT0Sku+999xz3/fSvD/v8/lxPooIzMwGnTfrAMxs/jgxmFnCicHMEk4MZpZwYjCzhBODmSUaE4OkT0l6XNL3a16XpE9IOinpQUlXdh+mmU1TTsVwG7BjyOvXA1v7/+0F/nH8sMxslhoTQ0TcC/x8yCE7gc9Ez2Fgg6SXdBWgmU3f2g7OsRE4PfD4TP+5x8oHStpLr6pgDWtecyHrO/h4M6vzvzzx04j4jbbv6yIxZIuIA8ABgPV6YVyta6f58Warzt1xxyOjvK+LUYlHgc0Djzf1nzOzBdVFYjgE/El/dOK1wFMRkVxGmNniaLyUkPQF4BrgEklngL8BngcQEZ8E7gRuAE4CvwT+bFLBmtl0NCaGiNjd8HoA7+4sIjObOc98NLOEE4OZJZwYzCzhxGBmCScGM0s4MZhZwonBzBJODGaWcGIws4QTg5klnBjMLOHEYGYJJwYzSzgxmFnCicHMEk4MZpZwYjCzhBODmSWcGMws4cRgZgknBjNLODGYWcKJwcwSTgxmlnBiMLOEE4OZJZwYzCzhxGBmCScGM0s4MZhZwonBzBJODGaWcGIws4QTg5klnBjMLJGVGCTtkHRC0klJt1a8/lJJ90g6KulBSTd0H6qZTUtjYpC0BtgPXA9sA3ZL2lY67K+BgxFxBbAL+IeuAzWz6cmpGK4CTkbEqYh4Brgd2Fk6JoD1/b8vBn7cXYhmNm1rM47ZCJweeHwGuLp0zIeAf5f0HuDXgDdWnUjSXmAvwAVc2DZWs6k474peQfzc0eMzjmR2uup83A3cFhGbgBuAz0pKzh0RByJie0Rsfx7nd/TRZta1nMTwKLB54PGm/nODbgYOAkTEfcAFwCVdBGhm05eTGI4AWyVtkbSOXufiodIx/w1cCyDplfQSw/90GajZtDx39PiqvoyAjMQQEWeBW4C7gIfojT4ck7RP0o39w/4SeIek7wJfAPZEREwqaDObrJzORyLiTuDO0nMfHPj7OPD6bkMzs1nxzEczSzgx2DLnXbFtabhutViN37mJE4OZJbL6GGz1WI298avxOzdxxWBmCVcMHfE02m4MXuv7t5wdVwxmlnDF0BG3bt3I+R1dnU2eKwYzSzgxmFnClxJjclk7ff6tJ88Vg5klXDGMya3X6rJaKkRXDGaWcMVgY1strSic+44r/Tu7YjCzhCsGG9tKbTULVdO0V3rl4IrBzBKuGFawNq3ZJFq+lbIgapFjH5UrBjNLuGIY0zxfY876OnjY540T0zz/5iuFKwYzSzgxmFnClxJjWoRythxjVSle9z3mqWyfdWfqPH3epLliMLOEK4aO1LUYXbUk89iBOO3ztnlPm2PLe0qMUpGstH0pXDGYWcIVw4R1NWTXdEybyURVr+e2mpOatPSLt78OgPWfu6/2mDYte5e/7bDzFnFvOP5U68+dZ64YzCzhimFMo7QQk3jPuC1UF30j47SWRaUwrCJ5ctvFy99ztP58o3yfnKql/P6lY1dIpVBwxWBmCUXETD54vV4YV+vamXz2IqlrxSbdos/DtfIoowXl93bRVzJ4bFG1DKsq5sndcccDEbG97ftcMZhZwn0MHZlUC1v0dj9Xen6ceQA5sdaNz3f1/drE0OXnVZ27Tf9N0a8xqd9lXmRVDJJ2SDoh6aSkW2uOeauk45KOSfp8t2Ga2TQ1VgyS1gD7geuAM8ARSYci4vjAMVuBvwJeHxFPSHrxpAI2s8nLuZS4CjgZEacAJN0O7AQGa6d3APsj4gmAiHi860DnXZsOrLr3tlnclDO01iaGJjmlcnmyT1fTwEeJZZTLpjYmNfV9XuRcSmwETg88PtN/btDlwOWSvinpsKQdVSeStFfS/ZLuf5anR4vYzCauq87HtcBW4BpgE3CvpFdHxJODB0XEAeAA9IYrO/rsuTSsBRllklK5QqiaEFSnfGfjYcqf06YFXHpPxrGjLAUfpeJpUznULYxq855RKrl5lFMxPApsHni8qf/coDPAoYh4NiJ+CPyAXqIwswWUUzEcAbZK2kIvIewC3lY65t+A3cC/SLqE3qXFqS4DnXdNrVmblrdodQbVDVtWnX+cVqvpc8ZVN8w3bPlyF5OKRllMVRVT0zGT/v2mpbFiiIizwC3AXcBDwMGIOCZpn6Qb+4fdBfxM0nHgHuD9EfGzSQVtZpPlKdEdmVav9DhToQvDll1Pa9FUzrV5+bk2S7Ob+jBGXT7e1A8xb6MTnhJtZp3xlOgJG7eFr7umzX1/1Xva9LaX5YwajPJdq67Nn3q5AFiffTZ45M0bALiU/GnOdb9X1W/Q1McwL5XCuFwxmFnCicHMEu587MjpD/4eAJv3/Scw2hToeS5Hu7qXQ5v7JNQZNvFpWvtj1P3/PvHe5wPwm/+xbunYWU52cuejmXXGFcMcGaelbXu+Om0mRxXnH2UCUptqqe5zys9DuoCrXIF0dQemqs8e/PzB510xmNmK4OHKjnRxDTvONXnV60ut49HmYwttWrcuK4UqxXX8xQ/3qtqfXPcMABuOLz/HsrtFNwzVbiiGMUeMsTyFu3yn6red6C0j+tdXlBcgLxZXDGaWcMXQsVEWMHV9g5NCOYY21/N1qq7nx9lTYVjlUFQKha17Hlj2eTlyJi+t/fgTADxzzWNDY8zx+V3XAfCLt89HH8OoXDGYWcKjEhMyqX0Wx4mli/NPau/KwuCS86KlLc8ZqIqlMIl9H4ZNja4bnRjkUQkzWxHcx9CxogVZWszz5SeXPT+o3MPdxbLiqvO3ibvLm5wOqy7qzjv43YtKoUnVvg9tYivUzZPIUSz4Klc1i8oVg5klnBjMLOHOx46ULwNyJsnkTPaZ9FZxdbq8O9Oox+ZOZ+6qQzRn2Lgu3rr//+PGNC53PppZZ9z52JEuJvsM0zSFOKejr+71YccMa9HLLewoMZU7XqsU5y//xlVDhOXOx5zO2uK1nO9R99rS4qmG32RRuGIws4Qrho6UW75isU759abnys+XW9K6ocxR9k0Y1u+RM1RXdy2eM+w6bJiyfJ5iyvLZv3jBsvdWDU2OshS8/J7ie7Xp/ygPTy86VwxmlnDF0JE2OzO3mThT1+KNsmdluQWsulNym1uulZd1F8p9AVXnrWulqzz89S0AbD7aPHloqb+gYXl15ffc9rr61/rqfqfirtSTmJI9C64YzCzheQwdK66LiymyxdLhWbQgbaqAUUYyytosH687/3/d9pql517x9/+37JhyddFmdKWNNvMw6kZmfGs3M1txXDF0LKdXvGnGY9WoRN1NTtvsxdj18u42O3znLv6q+u5N/Sxd3Tx3HDnbBcyCKwYz64wTg5klfCkxIaMsyMkpf5sWaw07f93rTZ+Za5RLorKcqdF1E6ogv6Nv2OSusmEb4BaKCU7zdj8GX0qYWWdcMXSszUSnNucb525MOR1/dTsqtdknctjCqLql0sPunZg7uatNh2Ubk7p71TS5YjCzzrhi6FhdizXuPRm7iKH8/GCLft9HPwnA9W/avSy2UYZf25jHHb6HLSfPjbOqGpvFRKeJVgySdkg6IemkpFuHHPcWSSGpdSBmNj8aKwZJa4AfANcBZ4AjwO6IOF467iLgK8A64JaIuH/YeVd6xTDOrlJtrk+7anHL+0SO0rp1XTnMapLSOJ83bxXQJCuGq4CTEXEqIp4Bbgd2Vhz3YeAjwK/aBmFm8yVn2fVG4PTA4zPA1YMHSLoS2BwRX5H0/roTSdoL7AW4gAvbR7sAipa2WO5b1YI0zUVocxPVKrlTiYuxd4BfvexpAC5+eF3jZ9cZ5+avbW5k02XLPnieNjfenfYckWkb+34Mks4DPgbsaTo2Ig4AB6B3KTHuZ5vZZOQkhkeBzQOPN/WfK1wEvAr4hiSA3wIOSbqxqZ9hJRt2O/G6XajbGDa/oOnGtIOVQqFY4vzIm8/vxVh6vc0+kaMsW64aKWmqqMapHIb1ZYxym7ym5xdNTh/DEWCrpC2S1gG7gEPFixHxVERcEhGXRcRlwGFgVScFs0XXmBgi4ixwC3AX8BBwMCKOSdon6cZJB2hm05fVxxARdwJ3lp77YM2x14wf1uJbGq7sPx53V6amY9qUsDl3Ms4pr3M3kK06X/F42AayTftW5HxeYdjlxyidnJPaXHheeEq0mSV8l+gJGaWVqLvr8rjnLTvx3ucDcMGp85eeK6qIl//hDwE4++UXtD7vsBa2Ke7y3Z0Hn6sb+h1296pROgfbdELmfp9F5YrBzBKuGCZklB2R2kxD7nrq7VKc1xTneww4N1V62A1IchaONQ0xjrJ7VdPzVbGMUmXkmLep0ONyxWBmCVcME1K0HG167nO02b25zrn9Gs7t21BuSYtJUMWiqmEtYnkEZlgcdXFXjU40TaCqMq2JR6NMilokrhjMLOGKYQ60uT7tokXM6fco+hSKnaE2DDl9l63l4Lnqqq2mm7dWGWffzqY4VyJXDGaWcGIws4QvJSaki8uDSWlz38aio3JpQ9mKCUhdGtzUduueByqP6br0b7rb9WrkisHMEq4YJmTRWpvyXhDFEGR5v4nBezlcSvuWtWlh1Lmh1HT4sxxrG9Ou4BZ9MZUrBjNLuGKYkknfA7DN+av2hyz6Hcr3rCyGDIv3FBOe4NxirK17muMrf2Y5xmLq9aDNHU4O6+o3z608cva7nGeuGMws4YphSma5X0KdYaMThaWp3RX3ZCwrvzZ4/qdeLiCdYl0oJlQtq3yGhz8TXdyfcxG4YjCzhCuGGZhEC9Jm6fEoS5sLg+9d/7nl5y0UIw6PDPQbFJVCebQj57Zt81JhrSauGMws4YphBmbVAuYs1W5a1p3T2750zJvPVQx1ox05/QizrhRGGVFa9J2oXDGYWcKJwcwSipjNFpLr9cK4WtfO5LPnTc4mql1+zij7JOS8J+c+l+Up0YtYZi+Su+OOByJie9v3uWIws4Qrhjk0Dx1XbTpIy8dWLZRq2rGpzfccp/O2647feR9KdcVgZp1xxbCKtalMRllGPOw9OftIzIt5qOBG5YrBzDrjCU6rWFc7cJdVVQPl6iGnUpjW9fsoIzIrnSsGM0u4YrDOVe0qNa3lyl3eKHY1VgoFVwxmlnDFYEMVN38ddpu1ulZ6Fi3uam7lu5RVMUjaIemEpJOSbq14/X2Sjkt6UNLXJF3afahmNi2NiUHSGmA/cD2wDdgtqTxAfRTYHhG/C9wB/G3XgZrZ9ORcSlwFnIyIUwCSbgd2Aks1W0TcM3D8YeCmLoO02SnfizFna/vCIk8MWu1yLiU2AqcHHp/pP1fnZuCrVS9I2ivpfkn3P8vT+VGa2VR12vko6SZgO/CGqtcj4gBwAHpTorv87EW06BNomhZCLer3srzE8CiweeDxpv5zy0h6I/AB4A0R4XLAbIHlJIYjwFZJW+glhF3A2wYPkHQF8E/Ajoh4vPMoV6hFalHb9C1UmdbNaKwbjX0MEXEWuAW4C3gIOBgRxyTtk3Rj/7CPAr8OfEnSdyQdmljEZjZxXnZtnVn0PpOVyMuuzawznhK9CkyrJXelsHK4YjCzhBODmSV8KbEKuMS3tlwxmFnCicHMEk4MZpZwYjCzhBODmSU8KmGt+OYrq4MrBjNLuGKwVlwlrA6uGMws4cRgZgknBjNLODGYWcKJwcwSTgxmlnBiMLOEE4OZJZwYzCzhxGBmCScGM0s4MZhZwonBzBJODGaWcGIws4QTg5klnBjMLOHEYGYJJwYzSzgxmFnCicHMEk4MZpbISgySdkg6IemkpFsrXj9f0hf7r39L0mVdB2pm09OYGCStAfYD1wPbgN2StpUOuxl4IiJ+G/g48JGuAzWz6cmpGK4CTkbEqYh4Brgd2Fk6Zifw6f7fdwDXSlJ3YZrZNOXsRLUROD3w+Axwdd0xEXFW0lPAi4CfDh4kaS+wt//w6bvjju+PEvSMXELp+8yxRYoVFiveRYoV4BWjvGmqW9RFxAHgAICk+yNi+zQ/fxyLFO8ixQqLFe8ixQq9eEd5X86lxKPA5oHHm/rPVR4jaS1wMfCzUQIys9nLSQxHgK2StkhaB+wCDpWOOQT8af/vPwa+HhHRXZhmNk2NlxL9PoNbgLuANcCnIuKYpH3A/RFxCPhn4LOSTgI/p5c8mhwYI+5ZWKR4FylWWKx4FylWGDFeuWE3szLPfDSzhBODmSUmnhgWaTp1Rqzvk3Rc0oOSvibp0lnEORDP0HgHjnuLpJA0s2G2nFglvbX/+x6T9Plpx1iKpenfwksl3SPpaP/fww2ziLMfy6ckPS6pcl6Qej7R/y4PSrqy8aQRMbH/6HVWPgy8DFgHfBfYVjrmz4FP9v/eBXxxkjGNGesfABf2/37XrGLNjbd/3EXAvcBhYPu8xgpsBY4CL+g/fvE8/7b0OvXe1f97G/CjGcb7+8CVwPdrXr8B+Cog4LXAt5rOOemKYZGmUzfGGhH3RMQv+w8P05vTMSs5vy3Ah+mtXfnVNIMryYn1HcD+iHgCICIen3KMg3LiDWB9/++LgR9PMb7lgUTcS280sM5O4DPRcxjYIOklw8456cRQNZ16Y90xEXEWKKZTT1tOrINuppeFZ6Ux3n7JuDkivjLNwCrk/LaXA5dL+qakw5J2TC26VE68HwJuknQGuBN4z3RCG0nbf9vTnRK9Uki6CdgOvGHWsdSRdB7wMWDPjEPJtZbe5cQ19CqxeyW9OiKenGlU9XYDt0XE30l6Hb15PK+KiOdmHVgXJl0xLNJ06pxYkfRG4APAjRHx9JRiq9IU70XAq4BvSPoRvWvLQzPqgMz5bc8AhyLi2Yj4IfADeoliFnLivRk4CBAR9wEX0FtgNY+y/m0vM+FOkbXAKWAL5zpxfqd0zLtZ3vl4cEYdODmxXkGvU2rrLGJsG2/p+G8wu87HnN92B/Dp/t+X0Ct9XzTH8X4V2NP/+5X0+hg0w38Pl1Hf+fgmlnc+frvxfFMI+AZ62f9h4AP95/bRa3Ghl2m/BJwEvg28bIY/blOsdwM/Ab7T/+/QrGLNibd07MwSQ+ZvK3qXPseB7wG75vm3pTcS8c1+0vgO8EczjPULwGPAs/Qqr5uBdwLvHPht9/e/y/dy/h14SrSZJTzz0cwSTgxmlnBiMLOEE4OZJZwYzCzhxGBmCScGM0v8P9cmKwSX+a1EAAAAAElFTkSuQmCC\n",
+            "text/plain": [
+              "<Figure size 432x288 with 1 Axes>"
+            ]
+          },
+          "metadata": {
+            "needs_background": "light"
+          }
+        }
+      ],
+      "source": [
+        "hist2d(x[:,0], x[:,1],100, range=[[0,1],[0,1]]);gca().set_aspect('equal');"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 60,
+      "id": "db6d76ae",
+      "metadata": {
+        "id": "db6d76ae"
+      },
+      "outputs": [],
+      "source": [
+        "x = model_sample.apply(params)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 61,
+      "id": "3a65c01d",
+      "metadata": {
+        "id": "3a65c01d",
+        "outputId": "247e927e-f3fe-4a2e-f2ef-1932c0297ca2",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 269
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAQYAAAD8CAYAAACVSwr3AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAASOElEQVR4nO3df4xdZZ3H8ffHKbUBOpUWXLCtUtdirGCW2gBqsmAAU3DTZqNrWmN22SU0smI2ceMuGzeswb90s5qYdHWbLKuSCJb+YSaxhg2KaeJa2y4g0GJlKC79wVJ+FKiwtB387h/nnOm957l37unMub9mPq+E9P547rnfGSaf+z3Pee45igjMzBq9pd8FmNngcTCYWcLBYGYJB4OZJRwMZpZwMJhZomMwSLpL0lFJj7d5XpK+KWlc0qOSVtdfppn1UpWO4TvA2imevwFYmf+3CfjWzMsys37qGAwRsQN4aYoh64HvRWYn8DZJF9VVoJn13rwatrEUONhw/1D+2LPlgZI2kXUVjDDywbMZreHtzayd4xx7ISIuONPX1REMlUXEFmALwKgWx5W6tpdvbzbnPBDb/mc6r6vjqMRhYHnD/WX5Y2Y2pOoIhjHgz/OjE1cBr0REshthZsOj466EpHuAa4DzJR0C/gk4CyAivg1sB24ExoHXgb/sVrFm1hsdgyEiNnZ4PoDP1VaRmfWdVz6aWcLBYGYJB4OZJRwMZpZwMJhZwsFgZgkHg5klHAxmlnAwmFnCwWBmCQeDmSUcDGaWcDCYWcLBYGYJB4OZJRwMZpZwMJhZwsFgZgkHg5klHAxmlnAwmFnCwWBmCQeDmSUcDGaWcDCYWcLBYGYJB4OZJRwMZpZwMJhZwsFgZgkHg5klHAxmlnAwmFnCwWBmCQeDmSUqBYOktZL2SxqXdHuL598p6UFJD0t6VNKN9ZdqZr3SMRgkjQCbgRuAVcBGSatKw/4R2BoRlwMbgH+tu1Az650qHcMVwHhEHIiIk8C9wPrSmABG89uLgCP1lWhmvTavwpilwMGG+4eAK0tjvgz8p6TPA+cA17XakKRNwCaABZx9prWaWY/UNfm4EfhORCwDbgTulpRsOyK2RMSaiFhzFm+t6a3NrG5VguEwsLzh/rL8sUY3A1sBIuIXwALg/DoKNLPeqxIMu4GVklZImk82uThWGvMMcC2ApPeRBcPzdRZqZr3TMRgiYgK4DbgfeILs6MNeSXdKWpcP+1vgFkm/Au4BboqI6FbRZtZdVSYfiYjtwPbSY3c03N4HfKTe0sysX7zy0cwSDgYzSzgYzCzhYDCzhIPBzBIOBjNLOBjMLOFgMLOEg8HMEg4GM0s4GMws4WAws4SDwcwSDgYzSzgYzCzhYDCzhIPBzBIOBjNLOBgMgHlLljBvyZJ+l2EDwsFgZolKJ4O14TLvPe8GYGL8QPPjeUcw8eKLTfcbH0u2Veoi2o2z2cUdg5klHAxmlvCuxCzR2PK/uficpsfe/MN3APDGouJ6oSsAeG3R6f/95z6TjRl56bWW2y/vlkD7XRYbfu4YzCzhjmGWeGP1isnbx5efBcBrH3svAOccya4W+No7BMAFVx8B4Hc/esfka06OngvAi9dkrx15Nusuzn42e82SvYsBOOuVE5Ovef7S7DXn5R1DeXLThpc7BjNLuGMYcMV+fNnhP7kQgPmvZt3AyVElYz5ww34A7lnxUwD+6Gu3AnDkoYsAOLthbNFNLL/opeyBbAgvHM/mK46/OgrA67f+X8OrXs1f+2HgdGdy3l2/yGqvcDjUBpM7BjNLuGMYQE2ftPn++8T1a4DT+/inst175r9a/BuTr3nhg78H4OiXs3mHjz/9pwBcuPg4AL97Z9YFvPWVU8l7n/h11okc+Wi2vdEnR/JtvpnV9uTo5Nhi/uH46jey2n63AIBjf/UhAC7Y8dzpn+m8RU0/jw02dwxmlnDHMADKy44bjzAseDr7pC3WHLz4/vkAnPfrrCtY9MhR4PScA8D7vvF80/YmSkcNFj2V1lC857nPZOsYVvywWPOQdQoX/lfWqfzvhxcmr/2zyx4C4D5WA6ePaCw8uHhyzIm8/kXHXslq8pzDQHPHYGYJdwyDIN//bin/hF30CE3/Fo8Xlt59+n7507jK+oIFDzXfHyltq5jBuJDLJscUcxW7/y6b/1iYdzOvrsy6jKK7aXwMVgJwzjZ3DIOsUscgaa2k/ZLGJd3eZsynJO2TtFfS9+st08x6qWPHIGkE2AxcDxwCdksai4h9DWNWAv8AfCQijkl6e7cKNrPuq7IrcQUwHhEHACTdC6wH9jWMuQXYHBHHACLiaN2Fzibl1r740lPsegyAs/L7jYoxI08daXptFVV2Ldqej6H0RamiRoBzdmX/vvbJqwBYene2oOrC/Etbxa4GwOsXZc1pcYi0fEjThzEHS5VdiaXAwYb7h/LHGl0CXCLp55J2SlrbakOSNknaI2nPKU60GmJmA6Cuycd5ZLNK1wDLgB2SLouIlxsHRcQWYAvAqBZHeSOzWdPXovNP1GLRD3kXQDGm4avPk5/k+b8TbbZbpYOYzhmcqnySL3rwyebt5o+fS4svaeUTksUCrZdv+QMAVvy9O4ZBUqVjOAwsb7i/LH+s0SFgLCJORcTTwG8opp/NbOhU6Rh2AyslrSALhA3Ap0tjfghsBP5D0vlkuxb+CCBdvAQtToZSXi7c8OndqSOYzlzDTLqMM6mhmA8BOG9XNqaYWyiWci88eKrpfZoO3XoxVN907BgiYgK4DbgfeALYGhF7Jd0paV0+7H7gRUn7gAeBL0aE/2+aDSlF9GdXf1SL40pd25f37oWp9ueLOYbpHGEYduXTzZ3KTze34Ons696Ncxo+ddzMPRDb/jsi1pzp67wk2swSXhLdJeUuoPH+vNJjvT4l2lTvV/f8Q9nkz5zPJRQdQ9EV6IrTS67fxPrFHYOZJRwMZpbwrkSXtZpAm2o3Y9BMtbswk7qL38eC/P7z+WHM4tyTABd/K1tiXV7UZd3njsHMEu4YuqzlFZz6fP2FmXwBq5U6fp7iy1QXlM4zYf3hjsHMEu4YuuxMvuLcqxomr1VxLD3r03Rqq2OuodB4uLJYANbvDmsucsdgZgl3DDVptwT6TL7i3C3JUZAWi4nKi666rXy0ZvL31XAiGLwkum/cMZhZwh1DTdqtTRjE/eNWn84T5efOoN5pLY1u0wU0XasznwMpf/Gq8fRy1h3uGMws4Y6hJu0+NQepUygkRyeY2X58HT9j+RR2kJ7kpugUBrELm23cMZhZwsFgZgnvStRkmNraycm8hutXDPLZklod8rXucsdgZgl3DHNQ+foP0HCti3YLj/rQEbXrFIpaGaIubdi4YzCzhDuGOahVF9BuSfQgzJ0k194sHu99KXOGOwYzS7hjmINadgHFFaDafDW712ew7uV7Wsodg5kl3DFYJu8MJr+K3eWrZE1nCbnXMfSOOwYzS7hjMCBd29Dtr423216rOYZ2ncIgrNacrV/ocsdgZgkHg5klvCthTcrnauh1mz5VS54sdCoOsfbRbNuFKLhjMLOEOwZrMjmZVqFT6NXEW9vtd/mqVbN1YrEKdwxmlnDHYE3qvq7lMBuEa4L0S6WOQdJaSfsljUu6fYpxn5AUktbUV6KZ9VrHjkHSCLAZuB44BOyWNBYR+0rjFgJ/A/yyG4XaYJiLn55z5edsVKVjuAIYj4gDEXESuBdY32LcV4CvAm/UWJ+Z9UGVOYalwMGG+4eAKxsHSFoNLI+IH0n6YrsNSdoEbAJYwNlnXq31Tbdm6Gey3W5/ks/loxIznnyU9Bbg68BNncZGxBZgC8CoFsdM39vMuqNKMBwGljfcX5Y/VlgIXAr8TBLAhcCYpHURsaeuQm3wTesaltP4NK5jVWbTF7PyFZTl7c3FTqFQZY5hN7BS0gpJ84ENwFjxZES8EhHnR8TFEXExsBNwKJgNsY7BEBETwG3A/cATwNaI2CvpTknrul2gmfVepTmGiNgObC89dkebsdfMvCwbNP2Y6Cs/dibLtdu+T4vdEK/yS3lJtJklHJZWmypdRadzPbY6W1Onq2O1PMNT8ZXs0hetytuoWvdc447BzBLuGKynOp1LsmmOIe8UiqtyF2ewntj1WNPzLbX5SvZUh1Tn8oKmMncMZpZwx2B90fYs0Y1dQP6pH8W8QP7cG9dnX949tvwsAC7Y8VzymmL7RZcReZcxnZrmIncMZpZwx2ADpWl9QZvrSSx4+qXs34c6X1dzpLiiVl0FzhHuGMws4WAws4R3JWygTLnw6FjnXYcyTyhOjzsGM0u4Y7CBciZXorLuccdgZgkHg5klHAxmlnAwmFnCwWBmCQeDmSUcDGaWcDCYWcLBYGYJB4OZJRwMZpZwMJhZwsFgZgkHg5klHAxmlnAwmFnCwWBmCQeDmSUcDGaWcDCYWcLBYGaJSsEgaa2k/ZLGJd3e4vkvSNon6VFJP5H0rvpLNbNe6RgMkkaAzcANwCpgo6RVpWEPA2si4gPANuBrdRdqZr1TpWO4AhiPiAMRcRK4F1jfOCAiHoyI1/O7O4Fl9ZZpZr1UJRiWAgcb7h/KH2vnZuDHrZ6QtEnSHkl7TnGiepVm1lO1XolK0meANcDVrZ6PiC3AFoBRLY4637uXpry+otksUCUYDgPLG+4vyx9rIuk64EvA1RHhdsBsiFUJht3ASkkryAJhA/DpxgGSLgf+DVgbEUdrr3LAuEuw2a7jHENETAC3AfcDTwBbI2KvpDslrcuH/TNwLnCfpEckjXWtYjPrukpzDBGxHdheeuyOhtvX1VzXQCnmFNwp2FzhlY9mlqj1qMRs5U7B5hp3DGaWcDCYWcLBYGYJB4OZJRwMZpZwMJhZwsFgZgkHg5klHAxmlnAwmFnCwWBmCQeDmSUcDGaWcDCYWcLBYGYJB4OZJRwMZpZwMJhZwsFgZgkHg5klHAxmlnAwmFnCwWBmCQeDmSUcDGaWcDCYWcLBYGYJB4OZJRwMZpZwMJhZwsFgZgkHg5klHAxmlqgUDJLWStovaVzS7S2ef6ukH+TP/1LSxXUXama90zEYJI0Am4EbgFXARkmrSsNuBo5FxHuAbwBfrbtQM+udKh3DFcB4RByIiJPAvcD60pj1wHfz29uAayWpvjLNrJfmVRizFDjYcP8QcGW7MRExIekVYAnwQuMgSZuATfndEw/EtsenU3SfnE/p5xlgw1QrDFe9w1QrwHun86IqwVCbiNgCbAGQtCci1vTy/WdimOodplphuOodplohq3c6r6uyK3EYWN5wf1n+WMsxkuYBi4AXp1OQmfVflWDYDayUtELSfGADMFYaMwb8RX77k8BPIyLqK9PMeqnjrkQ+Z3AbcD8wAtwVEXsl3QnsiYgx4N+BuyWNAy+RhUcnW2ZQdz8MU73DVCsMV73DVCtMs175g93Myrzy0cwSDgYzS3Q9GIZpOXWFWr8gaZ+kRyX9RNK7+lFnQz1T1tsw7hOSQlLfDrNVqVXSp/Lf715J3+91jaVaOv0tvFPSg5Iezv8ebuxHnXktd0k6KqnluiBlvpn/LI9KWt1xoxHRtf/IJiufAt4NzAd+Bawqjflr4Nv57Q3AD7pZ0wxr/Shwdn771n7VWrXefNxCYAewE1gzqLUCK4GHgfPy+28f5N8t2aTerfntVcBv+1jvHwOrgcfbPH8j8GNAwFXALztts9sdwzAtp+5Ya0Q8GBGv53d3kq3p6Jcqv1uAr5B9d+WNXhZXUqXWW4DNEXEMICKO9rjGRlXqDWA0v70IONLD+poLidhBdjSwnfXA9yKzE3ibpIum2ma3g6HVcuql7cZExARQLKfutSq1NrqZLIX7pWO9ecu4PCJ+1MvCWqjyu70EuETSzyXtlLS2Z9WlqtT7ZeAzkg4B24HP96a0aTnTv+3eLomeLSR9BlgDXN3vWtqR9Bbg68BNfS6lqnlkuxPXkHViOyRdFhEv97Wq9jYC34mIf5H0IbJ1PJdGxO/7XVgdut0xDNNy6iq1Iuk64EvAuog40aPaWulU70LgUuBnkn5Ltm851qcJyCq/20PAWEScioingd+QBUU/VKn3ZmArQET8AlhA9gWrQVTpb7tJlydF5gEHgBWcnsR5f2nM52iefNzapwmcKrVeTjYptbIfNZ5pvaXxP6N/k49Vfrdrge/mt88na32XDHC9PwZuym+/j2yOQX38e7iY9pOPH6d58nFXx+31oOAbydL/KeBL+WN3kn3iQpa09wHjwC7g3X385Xaq9QHgOeCR/L+xftVapd7S2L4FQ8Xfrch2ffYBjwEbBvl3S3Yk4ud5aDwCfKyPtd4DPAucIuu8bgY+C3y24Xe7Of9ZHqvyd+Al0WaW8MpHM0s4GMws4WAws4SDwcwSDgYzSzgYzCzhYDCzxP8DGsU9REGD0asAAAAASUVORK5CYII=\n",
+            "text/plain": [
+              "<Figure size 432x288 with 1 Axes>"
+            ]
+          },
+          "metadata": {
+            "needs_background": "light"
+          }
+        }
+      ],
+      "source": [
+        "hist2d(x[:,0], x[:,1],100, range=[[0,1],[0,1]]);gca().set_aspect('equal');"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "c91cedb4",
+      "metadata": {
+        "id": "c91cedb4"
+      },
+      "outputs": [],
+      "source": [
+        ""
+      ]
+    }
+  ],
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "name": "NF_mixture_sigmoid.ipynb",
+      "provenance": [],
+      "collapsed_sections": [],
+      "include_colab_link": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3 (ipykernel)",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.9.9"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/sbiexpt/bijectors.py
+++ b/sbiexpt/bijectors.py
@@ -110,3 +110,65 @@ class AffineSigmoidBijector(tfp.bijectors.Bijector):
       s, logdet = jnp.linalg.slogdet(jnp.atleast_2d(g))
       return s*logdet
     return jax.vmap(logdet_fn)(x, self.a, self.b, self.c)
+
+
+class MixtureAffineSigmoidBijector(tfp.bijectors.Bijector):
+  """
+  Bijector based on a ramp function, and implemented using an implicit 
+  layer. 
+
+  This implementation is based on the Smooth Normalizing Flows described
+  in: https://arxiv.org/abs/2110.00351
+
+  """
+
+  def __init__(self, a, b, c, p, name = 'MixtureAffineSigmoidBijector'):
+    """
+    Args:
+      rho: function of x that defines a ramp function between 0 and 1
+      a,b,c: scalar parameters of the coupling layer.
+    """
+    super(self.__class__, self).__init__(forward_min_event_ndims=0, name = name)
+    self.a = a
+    self.b = b
+    self.c = c
+    self.p = p
+
+    def sigmoid(x, a, b, c):
+      z = jax.scipy.special.logit(x) * a + b
+      y = jax.nn.sigmoid(z) * (1 - c) + c * x
+      return y 
+
+    # Rescaled bijection
+    def f(params, x):
+      a, b, c, p = params
+      a_in, b_in = [0. - 1e-1, 1. + 1e-1]
+      x = x[...,jnp.newaxis]
+      x = (x - a_in) / (b_in - a_in)
+      x0 = (jnp.zeros_like(x) - a_in)/ ( b_in - a_in)
+      x1 = (jnp.ones_like(x) - a_in) /( b_in - a_in)
+
+      y = sigmoid(x, a, b, c)
+      y0 = sigmoid(x0, a, b, c)
+      y1 = sigmoid(x1, a, b, c)
+      
+      y = (y - y0)/(y1 - y0)
+
+      return jnp.sum(p[..., jnp.newaxis]*(y*(1-c) + c *x), axis=0)
+    self.f = f
+
+    # Inverse bijector
+    self.inv_f = make_inverse_fn(f)
+
+  def _forward(self, x):
+    return jax.vmap(self.f)([self.a, self.b, self.c, self.p], x[...,0]).reshape(x.shape)
+
+  def _inverse(self, y):
+      return jax.vmap(self.inv_f)([self.a, self.b, self.c, self.p], y[...,0]).reshape(y.shape)
+
+  def _forward_log_det_jacobian(self, x):
+    def logdet_fn(x,a,b,c,p):
+      g = jax.grad(self.f, argnums=1)([a,b,c,p], x[...,0])
+      s, logdet = jnp.linalg.slogdet(jnp.atleast_2d(g))
+      return s*logdet
+    return jax.vmap(logdet_fn)(x, self.a, self.b, self.c, self.p)

--- a/sbiexpt/bijectors.py
+++ b/sbiexpt/bijectors.py
@@ -1,54 +1,10 @@
 import jax
-from jax import lax
 import jax.numpy as jnp
-from jaxopt import Bisection
-from functools import partial
+from sbiexpt.implicit_inverse import make_inverse_fn
 import tensorflow_probability as tfp; tfp = tfp.substrates.jax
 tfd = tfp.distributions
 
 __all__ = ['ImplicitRampBijector']
-
-@partial(jax.jit, static_argnums=(0,))
-def fwd_solver(f, z_init):
-  def body_fun(carry, i):
-    _, z  = carry
-    return (z, f(z)), i
-
-  init_carry = (z_init, f(z_init))
-  (_, z_star), i = lax.scan(body_fun, init_carry, jnp.arange(10))
-  return z_star
-
-def newton_solver(f, z_init):
-  f_root = lambda z: f(z)
-  g = lambda z: z - jnp.linalg.solve(jax.jacobian(f_root)(z), f_root(z))
-  return fwd_solver(g, z_init)
-
-def jaxopt_solver(f, z_init):
-  f_root = lambda z: jnp.squeeze(f(z))
-  bisec = Bisection(optimality_fun=f_root, lower=0.001, upper=0.999, check_bracket=False)
-  return bisec.run().params
-  #g = lambda z: z - jnp.linalg.solve(jax.jacobian(f_root)(z), f_root(z))
-  #return fwd_solver(g, z_init)
-
-@partial(jax.custom_vjp, nondiff_argnums=(0, 1))
-def fixed_point_layer(solver, f, params):
-  _, b, _, y = params
-  z_star = solver(lambda z: f(params, z), z_init=jnp.ones_like(y)*b) # initialized within [-1/2/a + b, 1/2/a + b]
-  return z_star
-
-def fixed_point_layer_fwd(solver, f, params):
-  z_star = fixed_point_layer(solver, f, params)
-  return z_star, (params, z_star)
-
-def fixed_point_layer_bwd(solver, f, res, z_star_bar):
-  x, z_star = res
-  _, vjp_a = jax.vjp(lambda x: f(x, z_star), x)
-  _, vjp_z = jax.vjp(lambda z: f(x, z), z_star)
-  return vjp_a(solver(lambda u: vjp_z(u)[0] + z_star_bar,
-                      z_init=jnp.ones_like(z_star)
-                      ))
-
-fixed_point_layer.defvjp(fixed_point_layer_fwd, fixed_point_layer_bwd)
 
 class ImplicitRampBijector(tfp.bijectors.Bijector):
   """
@@ -71,7 +27,8 @@ class ImplicitRampBijector(tfp.bijectors.Bijector):
     self.g = lambda x,a,b: self.sigma(a*(x-b)+0.5) 
 
     # Rescaled bijection
-    def f(x, a, b, c):
+    def f(params, x):
+      a, b, c = params
       b = (b - 1./(2*a))
       diff = x - b
       zs = jnp.stack([diff, -b*jnp.ones_like(x), 1 - b*jnp.ones_like(x)],axis=0)
@@ -81,27 +38,22 @@ class ImplicitRampBijector(tfp.bijectors.Bijector):
       return y*(1-c) + c *x
     self.f = f
 
-    # Defining inverse bijection
-    def fun(params, x):
-      a,b,c,y = params
-      return self.f(x,a,b,c) - y
-
     # Inverse bijector
-    self.inv_f = lambda x,a,b,c: fixed_point_layer(newton_solver, fun, (a,b,c,x))
+    self.inv_f = make_inverse_fn(f)
+
 
   def _forward(self, x):
-    return self.f(x, self.a, self.b, self.c)
+    return jax.vmap(self.f)([self.a, self.b, self.c], x)
 
   def _inverse(self, y):
-      return jax.vmap(self.inv_f)(y, self.a, self.b, self.c)
+      return jax.vmap(self.inv_f)([self.a, self.b, self.c], y)
 
   def _forward_log_det_jacobian(self, x):
-    x = x.reshape(self.b.shape)
     def logdet_fn(x,a,b,c):
       x = jnp.atleast_1d(x)
-      jac = jax.jacobian(self.f, argnums=0)(x,a,b,c)
-      s, logdet = jnp.linalg.slogdet(jac)
-      return jnp.atleast_1d(s*logdet)
+      g = jax.grad(self.f, argnums=1)([a,b,c], x)
+      s, logdet = jnp.linalg.slogdet(jnp.atleast_2d([g]))
+      return s*logdet
     return jax.vmap(logdet_fn)(x, self.a, self.b, self.c)
 
 
@@ -128,7 +80,8 @@ class AffineSigmoidBijector(tfp.bijectors.Bijector):
       return y 
 
     # Rescaled bijection
-    def f(x, a, b, c):
+    def f(params, x):
+      a, b, c = params
       a_in, b_in = [0. - 1e-1, 1. + 1e-1]
       
       x = (x - a_in) / (b_in - a_in)
@@ -142,26 +95,8 @@ class AffineSigmoidBijector(tfp.bijectors.Bijector):
       return (y - y0)/(y1 - y0)
     self.f = f
 
-    # Defining inverse bijection
-    def fun(params, x):
-      a,b,c,y = params
-      return self.f(x,a,b,c) - y
-
     # Inverse bijector
-    self.inv_f = lambda x,a,b,c: fixed_point_layer(jaxopt_solver, fun, (a,b,c,x))
-
-    # # Inverse bijector
-    # def inv_f(x,a,b,c):
-    #   x = x.squeeze()
-    #   a = a.squeeze()
-    #   b = b.squeeze()
-    #   c = c.squeeze()
-    #   def fun(x, aux):
-    #     a,b,c,y = aux
-    #     return jnp.squeeze(self.f(x,a,b,c) - y)
-    #   bisec = Bisection(optimality_fun=fun, lower=0.001, upper=0.999, check_bracket=False, jit=True)
-    #   return bisec.run(aux=(a,b,c,x)).params.reshape([1])
-    # self.inv_f = inv_f
+    self.inv_f = make_inverse_fn(f)
 
   def _forward(self, x):
     return jax.vmap(self.f)(x, self.a, self.b, self.c)
@@ -170,10 +105,9 @@ class AffineSigmoidBijector(tfp.bijectors.Bijector):
       return jax.vmap(self.inv_f)(y, self.a, self.b, self.c)
 
   def _forward_log_det_jacobian(self, x):
-    x = x.reshape(self.b.shape)
     def logdet_fn(x,a,b,c):
       x = jnp.atleast_1d(x)
-      jac = jax.jacobian(self.f, argnums=0)(x,a,b,c)
-      s, logdet = jnp.linalg.slogdet(jac)
-      return jnp.atleast_1d(s*logdet)
+      g = jax.grad(self.f, argnums=1)([a,b,c], x)
+      s, logdet = jnp.linalg.slogdet(jnp.atleast_2d([g]))
+      return s*logdet
     return jax.vmap(logdet_fn)(x, self.a, self.b, self.c)

--- a/sbiexpt/bijectors.py
+++ b/sbiexpt/bijectors.py
@@ -41,7 +41,6 @@ class ImplicitRampBijector(tfp.bijectors.Bijector):
     # Inverse bijector
     self.inv_f = make_inverse_fn(f)
 
-
   def _forward(self, x):
     return jax.vmap(self.f)([self.a, self.b, self.c], x)
 
@@ -50,12 +49,11 @@ class ImplicitRampBijector(tfp.bijectors.Bijector):
 
   def _forward_log_det_jacobian(self, x):
     def logdet_fn(x,a,b,c):
-      x = jnp.atleast_1d(x)
       g = jax.grad(self.f, argnums=1)([a,b,c], x)
-      s, logdet = jnp.linalg.slogdet(jnp.atleast_2d([g]))
+      s, logdet = jnp.linalg.slogdet(jnp.atleast_2d(g))
       return s*logdet
     return jax.vmap(logdet_fn)(x, self.a, self.b, self.c)
-
+    
 
 class AffineSigmoidBijector(tfp.bijectors.Bijector):
   """

--- a/sbiexpt/bijectors.py
+++ b/sbiexpt/bijectors.py
@@ -75,7 +75,7 @@ class AffineSigmoidBijector(tfp.bijectors.Bijector):
     self.c = c
 
     def sigmoid(x, a, b, c):
-      z = jax.scipy.special.logit(x) * a + b
+      z = (jax.scipy.special.logit(x) +b )* a
       y = jax.nn.sigmoid(z) * (1 - c) + c * x
       return y 
 
@@ -135,7 +135,7 @@ class MixtureAffineSigmoidBijector(tfp.bijectors.Bijector):
     self.p = p
 
     def sigmoid(x, a, b, c):
-      z = jax.scipy.special.logit(x) * a + b
+      z = (jax.scipy.special.logit(x) +b )* a
       y = jax.nn.sigmoid(z) * (1 - c) + c * x
       return y 
 

--- a/sbiexpt/bijectors.py
+++ b/sbiexpt/bijectors.py
@@ -123,6 +123,7 @@ class AffineSigmoidBijector(tfp.bijectors.Bijector):
     def f(x, a, b, c):
       a_in, b_in = [0. - 1e-1, 1. + 1e-1]
       
+      x = (x - a_in) / (b_in - a_in)
       x0 = (jnp.zeros_like(x) - a_in)/ ( b_in - a_in)
       x1 = (jnp.ones_like(x) - a_in) /( b_in - a_in)
 

--- a/sbiexpt/bijectors.py
+++ b/sbiexpt/bijectors.py
@@ -126,7 +126,7 @@ class AffineSigmoidBijector(tfp.bijectors.Bijector):
       x0 = (jnp.zeros_like(x) - a_in)/ ( b_in - a_in)
       x1 = (jnp.ones_like(x) - a_in) /( b_in - a_in)
 
-      y, y0, y1 = jnp.split(f(jnp.stack([x,x0,x1],axis=-1), a, b, c),3, axis=-1)
+      y, y0, y1 = jnp.split(sigmoid(jnp.stack([x,x0,x1],axis=-1), a, b, c),3, axis=-1)
 
       return (y - y0)/(y1 - y0)
     self.f = f

--- a/sbiexpt/bijectors.py
+++ b/sbiexpt/bijectors.py
@@ -154,7 +154,7 @@ class MixtureAffineSigmoidBijector(tfp.bijectors.Bijector):
       
       y = (y - y0)/(y1 - y0)
 
-      return jnp.sum(p[..., jnp.newaxis]*(y*(1-c) + c *x), axis=0)
+      return jnp.sum(p*(y*(1-c) + c *x), axis=0)
     self.f = f
 
     # Inverse bijector

--- a/sbiexpt/distributions.py
+++ b/sbiexpt/distributions.py
@@ -33,11 +33,10 @@ def get_swiss_roll(sigma, resolution=1024):
   )
   return distribution
 
+def get_two_moons(sigma, resolution=1024, normalized=False):
 
-def get_two_moons(sigma, resolution=1024):
   """
   Generate a TFP approximate distribution of the two moons dataset
-
   Parameters
   ----------
   sigma: float
@@ -45,7 +44,8 @@ def get_two_moons(sigma, resolution=1024):
   resolution: int
     Number of components in the gaussian mixture approximation of the
     distribution (default: 1024)
-
+  normalized: bool
+    Whether to recenter the distribution on [0,1]
   Returns
   -------
   distribution: TFP distribution
@@ -59,7 +59,10 @@ def get_two_moons(sigma, resolution=1024):
 
   X = np.append(outer_circ_x, inner_circ_x)
   Y = np.append(outer_circ_y, inner_circ_y)
-  coords = np.vstack([X, Y])
+
+  coords = np.vstack([X,Y])
+  if normalized:
+    coords = coords / 5 + 0.45
 
   distribution = tfd.MixtureSameFamily(
     mixture_distribution=tfd.Categorical(probs=np.ones(2*resolution) / resolution / 2),

--- a/sbiexpt/implicit_inverse.py
+++ b/sbiexpt/implicit_inverse.py
@@ -1,0 +1,48 @@
+# This module is to store our implicit inverse functions
+import jax
+from jax import lax
+import jax.numpy as jnp
+from functools import partial
+from jaxopt.linear_solve import solve_normal_cg
+from jaxopt import Bisection
+
+__all__ = ["make_inverse_fn"]
+
+
+@partial(jax.custom_vjp, nondiff_argnums=(0,))
+def root_bisection(f, params):
+  """
+  f: optimality fn with input arg (params, x)
+  """
+  bisec = Bisection(optimality_fun=f, lower=0.0, upper=1., 
+                    check_bracket=False, maxiter=100, tol=1e-06)
+  return bisec.run(None, params).params
+
+def root_bisection_fwd(f, params):
+  z_star = root_bisection(f, params)
+  return z_star, (params, z_star)
+
+def root_bwd(f, res, z_star_bar):
+  params, z_star = res
+  _, vjp_a = jax.vjp(lambda p: f(z_star, p), params)
+  _, vjp_z = jax.vjp(lambda z: f(z, params), z_star)
+  return vjp_a(solve_normal_cg(lambda u: vjp_z(u)[0], - z_star_bar))
+
+root_bisection.defvjp(root_bisection_fwd, root_bwd)
+
+
+def make_inverse_fn(f):
+  """ Defines the inverse of the input function, and provides implicit gradients
+  of the inverse.
+
+  Args:
+    f: callable of input shape (params, x)
+  Retuns:
+    inv_f: callable of with args (params, y)
+  """
+  def inv_fn(params, y):
+    def optimality_fn(x, params):
+      p, y = params
+      return f(p, x) - y
+    return root_bisection(optimality_fn, [params, y])
+  return inv_fn

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     'jax>=0.2.0',
     'jaxlib>=0.1.74',
     'tensorflow_probability>=0.14.1',
-    'scikit-learn>=0.21'
+    'scikit-learn>=0.21',
     'jaxopt>=0.2'
   ],
 )

--- a/setup.py
+++ b/setup.py
@@ -13,5 +13,6 @@ setup(
     'jaxlib>=0.1.74',
     'tensorflow_probability>=0.14.1',
     'scikit-learn>=0.21'
+    'jaxopt>=0.2'
   ],
 )

--- a/tests/test_bijectors.py
+++ b/tests/test_bijectors.py
@@ -18,10 +18,10 @@ def _make_inv_bijector(rho):
   def fun(t, a, b, c):
     batch_size = len(t)
     bijector = ImplicitRampBijector(rho, 
-                              jnp.ones((batch_size,1))*a,
-                              jnp.ones((batch_size,1))*b,
-                              jnp.ones((batch_size,1))*c)
-    y = bijector.forward(t.reshape([batch_size, 1]))*1.     
+                              jnp.ones((batch_size,))*a,
+                              jnp.ones((batch_size,))*b,
+                              jnp.ones((batch_size,))*c)
+    y = bijector.forward(t)*1.     
     return bijector.inverse(y).squeeze()
   return fun
 
@@ -36,22 +36,21 @@ def test_ramp_bijector_score():
   correctly on a Normalizing Flow using the ramp bijector.
   """
   batch_size = 100
-  d = 2
 
   def log_prob_fn(x, a, b, c):
-    flow = tfd.TransformedDistribution(distribution=tfd.MultivariateNormalDiag(loc=jnp.zeros(d)+0.5, scale_identity_multiplier=1.),
+    flow = tfd.TransformedDistribution(distribution=tfd.MultivariateNormalDiag(loc=jnp.zeros(1)+0.5, scale_identity_multiplier=1.),
                                         bijector=ImplicitRampBijector(lambda x: x**3,
-                                                                      jnp.ones((1,2))*a,
-                                                                      jnp.ones((1,2))*b,
-                                                                      jnp.ones((1,2))*c))
+                                                                      jnp.ones((1,))*a,
+                                                                      jnp.ones((1,))*b,
+                                                                      jnp.ones((1,))*c))
     return flow.log_prob(x)
   
-  fake_data = jnp.zeros([batch_size, d])+0.5
+  fake_data = jnp.zeros([batch_size, 1])+0.33333
   # With these parameters, the bijector should be the identity, so the log prob should be the same as that of the normal distribution
   # same for the score
-  log_prob, score = jax.vmap(jax.value_and_grad(lambda x: log_prob_fn(x.reshape([1,2]), 0.001, 0.5, 1.).squeeze()))(fake_data)
+  log_prob, score = jax.vmap(jax.value_and_grad(lambda x: log_prob_fn(x.reshape([1,]), 0.001, 0.5, 1.).squeeze()))(fake_data)
 
-  ref_log_prob, ref_score = jax.vmap(jax.value_and_grad(lambda x: tfd.MultivariateNormalDiag(loc=jnp.zeros(d)+0.5, scale_identity_multiplier=1.).log_prob(x)))(fake_data)
+  ref_log_prob, ref_score = jax.vmap(jax.value_and_grad(lambda x: tfd.MultivariateNormalDiag(loc=jnp.zeros(1)+0.5, scale_identity_multiplier=1.).log_prob(x)))(fake_data)
 
   assert_allclose(log_prob, ref_log_prob, rtol=1e-5, atol=1e-6)
   assert_allclose(score, ref_score, rtol=1e-5, atol=1e-6)
@@ -61,35 +60,35 @@ def test_ramp_bijector_inverse_cubic():
   """ Testing inverse of ramp bijector  for cubic ramp
   """
   batch_size = 100
-  x = np.linspace(0.001,0.999,batch_size)
+  x = jax.random.uniform(jax.random.PRNGKey(0), shape=[batch_size])
   
   test_inv = jax.jit(_make_inv_bijector(lambda x: x**3))
   for params in _test_params:
-    assert_allclose(test_inv(x, **params), x, rtol=1e-5, atol=1e-6)
+    assert_allclose(test_inv(x, **params), x, rtol=2e-3, atol=1e-6)
 
 
 def test_ramp_bijector_inverse_quintic():
   """ Testing inverse of ramp bijector for quintic ramp
   """
   batch_size = 100
-  x = np.linspace(0.001,0.999,batch_size)
+  x = jax.random.uniform(jax.random.PRNGKey(0), shape=[batch_size])
 
   # Testing for quintic ramp
   test_inv = jax.jit(_make_inv_bijector(lambda x: x**5))
   for params in _test_params:
-    assert_allclose(test_inv(x, **params), x, rtol=1e-5, atol=1e-6)
+    assert_allclose(test_inv(x, **params), x, rtol=2e-3, atol=1e-6)
 
 @xfail(reason="Ramp bijector still not working properly for non-odd order monomial ramps")
 def test_ramp_bijector_inverse_exp():
   """ Testing inverse of ramp bijector for exponential ramp
   """
   batch_size = 100
-  x = np.linspace(0.001,0.999,batch_size)
+  x = jax.random.uniform(jax.random.PRNGKey(0), shape=[batch_size])
 
   # Testing for quintic ramp
   test_inv = jax.jit(_make_inv_bijector(lambda x: jnp.exp(-1./(2*x**2))))
   for params in _test_params:
-    assert_allclose(test_inv(x, **params), x, rtol=1e-5, atol=1e-6)
+    assert_allclose(test_inv(x, **params), x, rtol=1e-3, atol=1e-6)
 
 
 


### PR DESCRIPTION
This PR adds a bunch of things:
- New inverse tools for making bijections without analytic inverses, based on [jaxopt](https://github.com/google/jaxopt) because the newton root finding method we had before wasnt stable enough. Note that for now, we can't directly use the implicit grads from jaxopt because of what looks like a little bug (https://github.com/google/jaxopt/issues/141). At least for now I've repurposed the implicit grads from @b-remy to bypass the jaxopt gradients, and everything seems to work fine.

- New type of coupling layer based on a sigmoid applied to an affine transformation. Also adds mixture of sigmoids, to provide expressivity. This type of transforms comes from the bgflow code, [here](https://github.com/noegroup/bgflow/blob/compact-interval-fixes/bgflow/nn/flow/transformer/sigmoid.py).

Annnnnd, finally we get flows that train by score matching \o/ (see [notebook](https://github.com/astrodeepnet/sbi_experiments/blob/affine_sigmoid_bijecctor/notebooks/score_matching/NF_mixture_sigmoid.ipynb))
![image](https://user-images.githubusercontent.com/861591/147429846-d29d4d2a-5f73-4c3b-a08a-9a6b4c749230.png)
Can probably be further fine-tuned, but at least it shows that we get non-stupid gradients. You can also train it directly by NLL, and woks quite well, a single coupling layer seems to be enough here.

There are a few things we will want to improve, in particular our bijectors here only work in the 2d case, but we can maybe look at that in a separate issue. This code should be enought to start experimenting.